### PR TITLE
Post graph definitions to Mackerel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 
 go:
   - "1.10.x"
+  - "1.11.x"
   - tip
 
 install:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,20 +3,25 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:a74730e052a45a3fab1d310fdef2ec17ae3d6af16228421e238320846f2aaec8"
   name = "github.com/alecthomas/template"
   packages = [
     ".",
-    "parse"
+    "parse",
   ]
+  pruneopts = ""
   revision = "a0175ee3bccc567396460bf5acd36800cb10c49c"
 
 [[projects]]
   branch = "master"
+  digest = "1:8483994d21404c8a1d489f6be756e25bfccd3b45d65821f25695577791a08e68"
   name = "github.com/alecthomas/units"
   packages = ["."]
+  pruneopts = ""
   revision = "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a"
 
 [[projects]]
+  digest = "1:1c82dd6a02941a3c4f23a32eca182717ab79691939e97d6b971466b780f06eea"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -47,70 +52,90 @@
     "service/s3",
     "service/s3/s3iface",
     "service/s3/s3manager",
-    "service/sts"
+    "service/sts",
   ]
+  pruneopts = ""
   revision = "9b0098a71f6d4d473a26ec8ad3c2feaac6eb1da6"
   version = "v1.13.32"
 
 [[projects]]
+  digest = "1:0bfeb5822bb3e0945f9455c2ee2ace0e6448e3a97474d4d001dcedf9f24e46fc"
   name = "github.com/go-ini/ini"
   packages = ["."]
+  pruneopts = ""
   revision = "ace140f73450505f33e8b8418216792275ae82a7"
   version = "v1.35.0"
 
 [[projects]]
+  digest = "1:e47598ace6916c75faff9ff541acd804d70f1c432a54120f5460fd4cca1b284a"
   name = "github.com/google/gops"
   packages = [
     "agent",
     "internal",
-    "signal"
+    "signal",
   ]
+  pruneopts = ""
   revision = "0e2aa5d22efec1603f7ded7097c500e9a36a13b3"
   version = "v0.3.3"
 
 [[projects]]
   branch = "master"
+  digest = "1:8b7dd3b581147b44cf522c66894b9119ab845c346d8f124d83f77ab499cf7ca3"
   name = "github.com/hashicorp/logutils"
   packages = ["."]
+  pruneopts = ""
   revision = "0dc08b1671f34c4250ce212759ebd880f743d883"
 
 [[projects]]
+  digest = "1:6f49eae0c1e5dab1dafafee34b207aeb7a42303105960944828c2079b92fc88e"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
+  pruneopts = ""
   revision = "0b12d6b5"
 
 [[projects]]
   branch = "master"
+  digest = "1:2c5ad58492804c40bdaf5d92039b0cde8b5becd2b7feeb37d7d1cc36a8aa8dbe"
   name = "github.com/kardianos/osext"
   packages = ["."]
+  pruneopts = ""
   revision = "ae77be60afb1dcacde03767a8c37337fad28ac14"
 
 [[projects]]
   branch = "master"
+  digest = "1:0a6f641929b6c23700fa2998262b6bae60a7c5c8b86edf61f36fd92629b0a357"
   name = "github.com/mackerelio/mackerel-client-go"
   packages = ["."]
+  pruneopts = ""
   revision = "458a40e9ccd85aa429f2894ea94f94d35bebd49f"
 
 [[projects]]
+  digest = "1:477cce5379198d3b8230b5c0961c61fcd1b337371cda81318e89a109245d83cb"
   name = "github.com/mattn/go-shellwords"
   packages = ["."]
+  pruneopts = ""
   revision = "02e3cf038dcea8290e44424da473dd12be796a8a"
   version = "v1.0.3"
 
 [[projects]]
+  digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = ""
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:0c7fc040198ab623aa073d218dc64a78bcd70f0697044cb397cf38a3b9465032"
   name = "github.com/tatsushid/go-fastping"
   packages = ["."]
+  pruneopts = ""
   revision = "d7bb493dee3e090e2ffb6914adddf17c1e7c026c"
 
 [[projects]]
   branch = "master"
+  digest = "1:58977d25cdcfe647173e2282e77f88797750d8124ad7417174afcaea301d4a6a"
   name = "golang.org/x/net"
   packages = [
     "bpf",
@@ -118,25 +143,43 @@
     "internal/iana",
     "internal/socket",
     "ipv4",
-    "ipv6"
+    "ipv6",
   ]
+  pruneopts = ""
   revision = "6078986fec03a1dcc236c34816c71b0e05018fda"
 
 [[projects]]
+  digest = "1:15d017551627c8bb091bde628215b2861bed128855343fdd570c62d08871f6e1"
   name = "gopkg.in/alecthomas/kingpin.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "947dcec5ba9c011838740e680966fd7087a71d0d"
   version = "v2.2.6"
 
 [[projects]]
+  digest = "1:f0620375dd1f6251d9973b5f2596228cc8042e887cd7f827e4220bc1ce8c30e2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e32f0d8c9ea1aeaef9e6236b8af9ea30cdc3703fb39b47ba95858017a7f02e6d"
+  input-imports = [
+    "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/session",
+    "github.com/aws/aws-sdk-go/service/s3",
+    "github.com/aws/aws-sdk-go/service/s3/s3manager",
+    "github.com/google/gops/agent",
+    "github.com/hashicorp/logutils",
+    "github.com/mackerelio/mackerel-client-go",
+    "github.com/mattn/go-shellwords",
+    "github.com/pkg/errors",
+    "github.com/tatsushid/go-fastping",
+    "gopkg.in/alecthomas/kingpin.v2",
+    "gopkg.in/yaml.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ setup_ci:
 	go get \
 		github.com/laher/goxc \
 		github.com/tcnksm/ghr \
-		github.com/golang/lint/golint \
+		golang.org/x/lint/golint \
 		github.com/golang/dep/cmd/dep
 	go get -d -t ./...
 

--- a/README.md
+++ b/README.md
@@ -186,9 +186,16 @@ Command probe executes command which outputs like Mackerel metric plugin.
 command:
   command: "/path/to/metric-command" # Path to execute command
   timeout: "5s"                      # Seconds of command timeout (default 15)
+  graph_defs: true                   # Post graph definitions to Mackerel (default false)
 ```
 
 Command probe handles command's output as host metric.
+
+When `graph_defs` is true, maprobe runs a command with `MACKEREL_AGENT_PLUGIN_META=1` environment variables and post graph definitions to Mackerel at first time.
+
+If the command does not return a valid graph definitions output, that is ignored.
+
+See also [ホストのカスタムメトリックを投稿する - Mackerel ヘルプ](https://mackerel.io/ja/docs/entry/advanced/custom-metrics#graph-schema).
 
 #### Example of automated cleanup for terminated EC2 instances.
 

--- a/command.go
+++ b/command.go
@@ -2,6 +2,7 @@ package maprobe
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	mackerel "github.com/mackerelio/mackerel-client-go"
@@ -17,17 +19,23 @@ import (
 	"github.com/pkg/errors"
 )
 
+const CustomPrefix = "custom."
+
 var DefaultCommandTimeout = 15 * time.Second
 
+var graphDefsPosted = sync.Map{}
+
 type CommandProbeConfig struct {
-	Command string        `yaml:"command"`
-	Timeout time.Duration `yaml:"timeout"`
+	Command   string        `yaml:"command"`
+	Timeout   time.Duration `yaml:"timeout"`
+	GraphDefs bool          `yaml:"graph_defs"`
 }
 
-func (pc *CommandProbeConfig) GenerateProbe(host *mackerel.Host) (Probe, error) {
+func (pc *CommandProbeConfig) GenerateProbe(host *mackerel.Host, client *mackerel.Client) (Probe, error) {
 	p := &CommandProbe{
-		hostID:  host.ID,
-		Timeout: pc.Timeout,
+		hostID:    host.ID,
+		Timeout:   pc.Timeout,
+		GraphDefs: pc.GraphDefs,
 	}
 	var err error
 
@@ -39,9 +47,18 @@ func (pc *CommandProbeConfig) GenerateProbe(host *mackerel.Host) (Probe, error) 
 	if err != nil {
 		return nil, errors.Wrap(err, "parse command failed")
 	}
+	if len(p.Command) == 0 {
+		return nil, errors.Wrap(err, "command required")
+	}
 
 	if p.Timeout == 0 {
 		p.Timeout = DefaultCommandTimeout
+	}
+
+	if p.GraphDefs && client != nil {
+		if err := p.PostGraphDefs(client, pc); err != nil {
+			log.Printf("[warn] failed to post graph defs for %#v: %s", p, err)
+		}
 	}
 
 	return p, nil
@@ -50,8 +67,9 @@ func (pc *CommandProbeConfig) GenerateProbe(host *mackerel.Host) (Probe, error) 
 type CommandProbe struct {
 	hostID string
 
-	Command []string
-	Timeout time.Duration
+	Command   []string
+	Timeout   time.Duration
+	GraphDefs bool
 }
 
 func (p *CommandProbe) HostID() string {
@@ -91,6 +109,9 @@ func (p *CommandProbe) Run(ctx context.Context) (ms Metrics, err error) {
 			continue
 		}
 		m.HostID = p.hostID
+		if p.GraphDefs {
+			m.Name = CustomPrefix + m.Name
+		}
 		ms = append(ms, m)
 	}
 
@@ -100,6 +121,100 @@ func (p *CommandProbe) Run(ctx context.Context) (ms Metrics, err error) {
 	}
 
 	return ms, nil
+}
+
+type GraphsOutput struct {
+	Graphs map[string]Graph `json:"graphs"`
+}
+
+type Graph struct {
+	Label   string            `json:"label"`
+	Unit    string            `json:"unit"`
+	Metrics []GraphDefsMetric `json:"metrics"`
+}
+
+type GraphDefsMetric struct {
+	Name    string `json:"name"`
+	Label   string `json:"label"`
+	Stacked bool   `json:"stacked"`
+}
+
+var pluginMetaHeaderLine = []byte("# mackerel-agent-plugin\n")
+
+func (p *CommandProbe) PostGraphDefs(client *mackerel.Client, pc *CommandProbeConfig) error {
+	if _, found := graphDefsPosted.Load(pc); found {
+		log.Printf("[trace] graphDefsPosted %v", pc)
+		return nil
+	}
+
+	out, err := p.GetGraphDefs()
+	if err != nil {
+		graphDefsPosted.Store(pc, struct{}{})
+		return err
+	}
+	log.Printf("[trace] Got graph defs %#v", out)
+
+	payloads := make([]*mackerel.GraphDefsParam, 0, len(out.Graphs))
+	for _name, g := range out.Graphs {
+		name := CustomPrefix + _name
+		metrics := make([]*mackerel.GraphDefsMetric, 0, len(g.Metrics))
+		for _, m := range g.Metrics {
+			metrics = append(metrics, &mackerel.GraphDefsMetric{
+				Name:        name + "." + m.Name,
+				DisplayName: m.Label,
+				IsStacked:   m.Stacked,
+			})
+		}
+		payloads = append(payloads, &mackerel.GraphDefsParam{
+			Name:        name,
+			DisplayName: g.Label,
+			Unit:        g.Unit,
+			Metrics:     metrics,
+		})
+	}
+	b, _ := json.Marshal(payloads)
+	log.Println("[trace] create to graph defs", string(b))
+	if err := client.CreateGraphDefs(payloads); err != nil {
+		// When failed to post to Mackerel, graphDefsPosted shouldnot be stored.
+		return errors.Wrap(err, "could not create graph defs")
+	}
+	log.Printf("[info] success to create graph defs for %s %v", p.hostID, p.Command)
+
+	graphDefsPosted.Store(pc, struct{}{})
+	return nil
+}
+
+func (p *CommandProbe) GetGraphDefs() (*GraphsOutput, error) {
+	log.Printf("[trace] Get graph defs for %s %v", p.hostID, p.Command)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, p.Command[0], p.Command[1:]...)
+	cmd.Env = append(os.Environ(), "MACKEREL_AGENT_PLUGIN_META=1")
+	cmd.Stderr = os.Stderr
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, errors.Wrap(err, "stdout open failed")
+	}
+	r := bufio.NewReader(stdout)
+	if err := cmd.Start(); err != nil {
+		return nil, errors.Wrap(err, "command execute failed")
+	}
+
+	header, err := r.ReadBytes('\n')
+	if err != nil {
+		return nil, errors.Wrap(err, "could not fetch a first line")
+	}
+	if !bytes.Equal(header, pluginMetaHeaderLine) {
+		// invalid header
+		return nil, fmt.Errorf("%s didn't output graph defs", p.Command[0])
+	}
+
+	var out GraphsOutput
+	if err := json.NewDecoder(r).Decode(&out); err != nil {
+		return nil, errors.Wrap(err, "could not decode graph defs output")
+	}
+	return &out, nil
 }
 
 func parseMetricLine(b string) (Metric, error) {

--- a/command_test.go
+++ b/command_test.go
@@ -12,7 +12,8 @@ import (
 
 var commandProbesConfig = []*maprobe.CommandProbeConfig{
 	&maprobe.CommandProbeConfig{
-		Command: `sh -c 'echo "test.{{ .Host.ID }}.ok\t1\t1523261168"'`,
+		Command:   `./test/command-plugin {{ .Host.ID }}`,
+		GraphDefs: true,
 	},
 }
 
@@ -29,7 +30,7 @@ var commandProbesExpect = []maprobe.Metrics{
 
 func TestCommand(t *testing.T) {
 	for i, pc := range commandProbesConfig {
-		probe, _ := pc.GenerateProbe(&mackerel.Host{ID: "test"})
+		probe, _ := pc.GenerateProbe(&mackerel.Host{ID: "test"}, nil)
 		ms, err := probe.Run(context.Background())
 		if err != nil {
 			t.Error(err)

--- a/command_test.go
+++ b/command_test.go
@@ -15,9 +15,20 @@ var commandProbesConfig = []*maprobe.CommandProbeConfig{
 		Command:   `./test/command-plugin {{ .Host.ID }}`,
 		GraphDefs: true,
 	},
+	&maprobe.CommandProbeConfig{
+		Command: `./test/command-plugin {{ .Host.ID }}`,
+	},
 }
 
 var commandProbesExpect = []maprobe.Metrics{
+	maprobe.Metrics{
+		maprobe.Metric{
+			HostID:    "test",
+			Name:      "custom.test.test.ok",
+			Value:     1,
+			Timestamp: time.Unix(1523261168, 0),
+		},
+	},
 	maprobe.Metrics{
 		maprobe.Metric{
 			HostID:    "test",

--- a/config.go
+++ b/config.go
@@ -38,10 +38,10 @@ type ProbeDefinition struct {
 	Command *CommandProbeConfig `yaml:"command"`
 }
 
-func (pc *ProbeDefinition) GenerateProbes(host *mackerel.Host) []Probe {
+func (pd *ProbeDefinition) GenerateProbes(host *mackerel.Host, client *mackerel.Client) []Probe {
 	var probes []Probe
 
-	if pingConfig := pc.Ping; pingConfig != nil {
+	if pingConfig := pd.Ping; pingConfig != nil {
 		p, err := pingConfig.GenerateProbe(host)
 		if err != nil {
 			log.Printf("[error] cannot generate ping probe. HostID:%s Name:%s %s", host.ID, host.Name, err)
@@ -50,7 +50,7 @@ func (pc *ProbeDefinition) GenerateProbes(host *mackerel.Host) []Probe {
 		}
 	}
 
-	if tcpConfig := pc.TCP; tcpConfig != nil {
+	if tcpConfig := pd.TCP; tcpConfig != nil {
 		p, err := tcpConfig.GenerateProbe(host)
 		if err != nil {
 			log.Printf("[error] cannot generate tcp probe. HostID:%s Name:%s %s", host.ID, host.Name, err)
@@ -59,7 +59,7 @@ func (pc *ProbeDefinition) GenerateProbes(host *mackerel.Host) []Probe {
 		}
 	}
 
-	if httpConfig := pc.HTTP; httpConfig != nil {
+	if httpConfig := pd.HTTP; httpConfig != nil {
 		p, err := httpConfig.GenerateProbe(host)
 		if err != nil {
 			log.Printf("[error] cannot generate http probe. HostID:%s Name:%s %s", host.ID, host.Name, err)
@@ -68,8 +68,8 @@ func (pc *ProbeDefinition) GenerateProbes(host *mackerel.Host) []Probe {
 		}
 	}
 
-	if commandConfig := pc.Command; commandConfig != nil {
-		p, err := commandConfig.GenerateProbe(host)
+	if commandConfig := pd.Command; commandConfig != nil {
+		p, err := commandConfig.GenerateProbe(host, client)
 		if err != nil {
 			log.Printf("[error] cannot generate command probe. HostID:%s Name:%s %s", host.ID, host.Name, err)
 		} else {

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -7,7 +7,13 @@ probes:
       headers:
       no_check_certificate: true
     command:
-      command: "mackerel-plugin-redis -host 10.8.0.1"
+      command: "mackerel-plugin-memcached -host 10.8.0.1"
+      graph_defs: on
+  - service: Home
+    role: server
+    command:
+      command: "mackerel-plugin-nginx -host 10.8.0.1 -port 80"
+      graph_defs: on
 
   - service: Home
     ping:

--- a/maprobe.go
+++ b/maprobe.go
@@ -120,7 +120,7 @@ func runProbes(ctx context.Context, pd *ProbeDefinition, client *mackerel.Client
 			lock()
 			defer unlock()
 			defer wg2.Done()
-			for _, probe := range pd.GenerateProbes(host) {
+			for _, probe := range pd.GenerateProbes(host, client) {
 				log.Printf("[debug] probing host id:%s name:%s probe:%s", host.ID, host.Name, probe)
 				metrics, err := probe.Run(ctx)
 				if err != nil {

--- a/probe.go
+++ b/probe.go
@@ -42,7 +42,7 @@ type Metric struct {
 
 func (m Metric) HostMetricValue() *mackerel.HostMetricValue {
 	mv := &mackerel.MetricValue{
-		Name:  m.Name,
+		Name:  "custom." + m.Name,
 		Time:  m.Timestamp.Unix(),
 		Value: m.Value,
 	}

--- a/test/command-plugin
+++ b/test/command-plugin
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+if [ "${MACKEREL_AGENT_PLUGIN_META}" = "1" ]
+then
+    echo "# mackerel-agent-plugin"
+    cat <<EOF
+{
+  "graphs": {
+    "test.foo": {
+      "label": "Test Foo",
+      "unit": "bytes",
+      "metrics": [
+        {
+          "name": "foo",
+          "label": "Foo",
+          "diff": true,
+          "type": "uint64",
+          "stacked": false,
+          "scale": 0
+        }
+      ]
+    },
+    "test.bar": {
+      "label": "Test Bar",
+      "unit": "bytes",
+      "metrics": [
+        {
+          "name": "bar",
+          "label": "Bar",
+          "diff": true,
+          "type": "uint64",
+          "stacked": false,
+          "scale": 0
+        }
+      ]
+    }
+  }
+}
+EOF
+else
+    echo "test.$1.ok\t1\t1523261168"
+fi


### PR DESCRIPTION
Implement `graph_defs: true` for command probe.

When `graph_defs` is true, maprobe runs a command with `MACKEREL_AGENT_PLUGIN_META=1` environment variables and post graph definitions to Mackerel at first time.

refs #2 