### PR TITLE
Aggregates

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -67,6 +67,20 @@
   version = "v1.35.0"
 
 [[projects]]
+  digest = "1:f9f45f75f332e03fc7e9fe9188ea4e1ce4d14779ef34fa1b023da67518e36327"
+  name = "github.com/google/go-cmp"
+  packages = [
+    "cmp",
+    "cmp/cmpopts",
+    "cmp/internal/diff",
+    "cmp/internal/function",
+    "cmp/internal/value",
+  ]
+  pruneopts = ""
+  revision = "3af367b6b30c263d47e8895973edcca9a49cf029"
+  version = "v0.2.0"
+
+[[projects]]
   digest = "1:e47598ace6916c75faff9ff541acd804d70f1c432a54120f5460fd4cca1b284a"
   name = "github.com/google/gops"
   packages = [
@@ -172,6 +186,8 @@
     "github.com/aws/aws-sdk-go/aws/session",
     "github.com/aws/aws-sdk-go/service/s3",
     "github.com/aws/aws-sdk-go/service/s3/s3manager",
+    "github.com/google/go-cmp/cmp",
+    "github.com/google/go-cmp/cmp/cmpopts",
     "github.com/google/gops/agent",
     "github.com/hashicorp/logutils",
     "github.com/mackerelio/mackerel-client-go",

--- a/aggregate.go
+++ b/aggregate.go
@@ -1,0 +1,39 @@
+package maprobe
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	mackerel "github.com/mackerelio/mackerel-client-go"
+)
+
+type ServiceMetrics []ServiceMetric
+
+func (ms ServiceMetrics) String() string {
+	var b strings.Builder
+	for _, m := range ms {
+		b.WriteString(m.String())
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+type ServiceMetric struct {
+	Service   string
+	Name      string
+	Value     float64
+	Timestamp time.Time
+}
+
+func (m ServiceMetric) MetricValue() *mackerel.MetricValue {
+	return &mackerel.MetricValue{
+		Name:  m.Name,
+		Time:  m.Timestamp.Unix(),
+		Value: m.Value,
+	}
+}
+
+func (m ServiceMetric) String() string {
+	return fmt.Sprintf("%s\t%f\t%d", m.Name, m.Value, m.Timestamp.Unix())
+}

--- a/calc.go
+++ b/calc.go
@@ -1,0 +1,32 @@
+package maprobe
+
+import "math"
+
+func sum(values []float64) (value float64) {
+	for _, v := range values {
+		value = value + v
+	}
+	return
+}
+
+func min(values []float64) (value float64) {
+	for _, v := range values {
+		value = math.Min(v, value)
+	}
+	return
+}
+
+func max(values []float64) (value float64) {
+	for _, v := range values {
+		value = math.Max(v, value)
+	}
+	return
+}
+
+func count(values []float64) (value float64) {
+	return float64(len(values))
+}
+
+func avg(values []float64) (value float64) {
+	return sum(values) / count(values)
+}

--- a/client.go
+++ b/client.go
@@ -1,0 +1,48 @@
+package maprobe
+
+import (
+	"log"
+	"sync"
+	"time"
+
+	mackerel "github.com/mackerelio/mackerel-client-go"
+)
+
+func fetchLatestMetricValues(client *mackerel.Client, hostIDs []string, metricNames []string) (mackerel.LatestMetricValues, error) {
+	to := time.Now().Add(-1 * time.Minute)
+	from := to.Add(metricTimeMargin)
+	result := make(mackerel.LatestMetricValues, len(hostIDs))
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for _, hostID := range hostIDs {
+		for _, metricName := range metricNames {
+			wg.Add(1)
+			clientSem <- struct{}{}
+			go func(hostID, metricName string) {
+				defer func() {
+					<-clientSem
+					wg.Done()
+				}()
+				log.Printf("[debug] fetching host metric values: %s %s from %s to %s", hostID, metricName, from, to)
+				mvs, err := client.FetchHostMetricValues(hostID, metricName, from.Unix(), to.Unix())
+				if err != nil {
+					log.Printf("[warn] failed to fetch host metric values: %s %s from %s to %s", hostID, metricName, from, to)
+					return
+				}
+				if len(mvs) == 0 {
+					return
+				}
+				mu.Lock()
+				if result[hostID] == nil {
+					result[hostID] = make(map[string]*mackerel.MetricValue, len(metricNames))
+				}
+				result[hostID][metricName] = &(mvs[len(mvs)-1])
+				mu.Unlock()
+			}(hostID, metricName)
+		}
+	}
+	wg.Wait()
+	return result, nil
+}

--- a/client.go
+++ b/client.go
@@ -25,7 +25,7 @@ func fetchLatestMetricValues(client *mackerel.Client, hostIDs []string, metricNa
 					<-clientSem
 					wg.Done()
 				}()
-				log.Printf("[debug] fetching host metric values: %s %s from %s to %s", hostID, metricName, from, to)
+				log.Printf("[trace] fetching host metric values: %s %s from %s to %s", hostID, metricName, from, to)
 				mvs, err := client.FetchHostMetricValues(hostID, metricName, from.Unix(), to.Unix())
 				if err != nil {
 					log.Printf("[warn] failed to fetch host metric values: %s %s from %s to %s", hostID, metricName, from, to)

--- a/command.go
+++ b/command.go
@@ -85,7 +85,7 @@ func (p *CommandProbe) String() string {
 	return string(b)
 }
 
-func (p *CommandProbe) Run(ctx context.Context) (ms Metrics, err error) {
+func (p *CommandProbe) Run(ctx context.Context) (ms HostMetrics, err error) {
 	ctx, cancel := context.WithTimeout(ctx, p.Timeout)
 	defer cancel()
 
@@ -217,13 +217,13 @@ func (p *CommandProbe) GetGraphDefs() (*GraphsOutput, error) {
 	return &out, nil
 }
 
-func parseMetricLine(b string) (Metric, error) {
+func parseMetricLine(b string) (HostMetric, error) {
 	cols := strings.SplitN(b, "\t", 3)
 	if len(cols) < 3 {
-		return Metric{}, errors.New("invalid metric format. insufficient columns")
+		return HostMetric{}, errors.New("invalid metric format. insufficient columns")
 	}
 	name, value, timestamp := cols[0], cols[1], cols[2]
-	m := Metric{
+	m := HostMetric{
 		Name: name,
 	}
 

--- a/command_test.go
+++ b/command_test.go
@@ -20,17 +20,17 @@ var commandProbesConfig = []*maprobe.CommandProbeConfig{
 	},
 }
 
-var commandProbesExpect = []maprobe.Metrics{
-	maprobe.Metrics{
-		maprobe.Metric{
+var commandProbesExpect = []maprobe.HostMetrics{
+	maprobe.HostMetrics{
+		maprobe.HostMetric{
 			HostID:    "test",
 			Name:      "custom.test.test.ok",
 			Value:     1,
 			Timestamp: time.Unix(1523261168, 0),
 		},
 	},
-	maprobe.Metrics{
-		maprobe.Metric{
+	maprobe.HostMetrics{
+		maprobe.HostMetric{
 			HostID:    "test",
 			Name:      "test.test.ok",
 			Value:     1,

--- a/config.go
+++ b/config.go
@@ -28,6 +28,8 @@ type Config struct {
 
 	Aggregates            []*AggregateDefinition `yaml:"aggregates"`
 	PostAggregatedMetrics bool                   `yaml:"post_aggregated_metrics"`
+
+	ProbeOnly *bool `yaml:"probe_only"` // deprecated
 }
 
 type ProbeDefinition struct {
@@ -119,6 +121,10 @@ func (c *Config) initialize() {
 func (c *Config) validate() error {
 	if c.APIKey == "" {
 		return errors.New("no API Key")
+	}
+	if o := c.ProbeOnly; o != nil {
+		log.Println("[warn] configuration probe_only is not deprecated. use post_probed_metrics")
+		c.PostProbedMetrics = !*o
 	}
 	return nil
 }

--- a/http.go
+++ b/http.go
@@ -112,7 +112,7 @@ func (p *HTTPProbe) String() string {
 	return string(b)
 }
 
-func (p *HTTPProbe) Run(ctx context.Context) (ms Metrics, err error) {
+func (p *HTTPProbe) Run(ctx context.Context) (ms HostMetrics, err error) {
 	var ok bool
 	start := time.Now()
 	defer func() {

--- a/maprobe.go
+++ b/maprobe.go
@@ -41,7 +41,7 @@ func Run(ctx context.Context, wg *sync.WaitGroup, configPath string, once bool) 
 	log.Println("[debug]", conf.String())
 	client := mackerel.NewClient(conf.APIKey)
 
-	ch := make(chan Metric, PostMetricBufferLength*10)
+	ch := make(chan HostMetric, PostMetricBufferLength*10)
 	defer close(ch)
 
 	if conf.ProbeOnly {
@@ -84,7 +84,7 @@ func Run(ctx context.Context, wg *sync.WaitGroup, configPath string, once bool) 
 	return nil
 }
 
-func runProbes(ctx context.Context, pd *ProbeDefinition, client *mackerel.Client, ch chan Metric, wg *sync.WaitGroup) {
+func runProbes(ctx context.Context, pd *ProbeDefinition, client *mackerel.Client, ch chan HostMetric, wg *sync.WaitGroup) {
 	defer wg.Done()
 	log.Printf(
 		"[debug] finding hosts service:%s roles:%s statuses:%v",
@@ -135,7 +135,7 @@ func runProbes(ctx context.Context, pd *ProbeDefinition, client *mackerel.Client
 	wg2.Wait()
 }
 
-func postMetricWorker(wg *sync.WaitGroup, client *mackerel.Client, ch chan Metric) {
+func postMetricWorker(wg *sync.WaitGroup, client *mackerel.Client, ch chan HostMetric) {
 	defer wg.Done()
 	ticker := time.NewTicker(10 * time.Second)
 	mvs := make([]*mackerel.HostMetricValue, 0, PostMetricBufferLength)
@@ -171,7 +171,7 @@ func postMetricWorker(wg *sync.WaitGroup, client *mackerel.Client, ch chan Metri
 	}
 }
 
-func dumpMetricWorker(ch chan Metric) {
+func dumpMetricWorker(ch chan HostMetric) {
 	for m := range ch {
 		b, _ := json.Marshal(m.HostMetricValue())
 		log.Println("[debug]", string(b))

--- a/maprobe.go
+++ b/maprobe.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"math"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -13,10 +15,13 @@ import (
 
 var (
 	MaxConcurrency         = 100
+	MaxClientConcurrency   = 5
 	PostMetricBufferLength = 100
 	sem                    = make(chan struct{}, MaxConcurrency)
+	clientSem              = make(chan struct{}, MaxClientConcurrency)
 	ProbeInterval          = 60 * time.Second
 	mackerelRetryInterval  = 10 * time.Second
+	metricTimeMargin       = -3 * time.Minute
 )
 
 func lock() {
@@ -41,14 +46,27 @@ func Run(ctx context.Context, wg *sync.WaitGroup, configPath string, once bool) 
 	log.Println("[debug]", conf.String())
 	client := mackerel.NewClient(conf.APIKey)
 
-	ch := make(chan HostMetric, PostMetricBufferLength*10)
-	defer close(ch)
+	hch := make(chan HostMetric, PostMetricBufferLength*10)
+	defer close(hch)
+	sch := make(chan ServiceMetric, PostMetricBufferLength*10)
+	defer close(sch)
 
-	if conf.ProbeOnly {
-		go dumpMetricWorker(ch)
-	} else {
-		wg.Add(1)
-		go postMetricWorker(wg, client, ch)
+	if len(conf.Probes) > 0 {
+		if conf.PostProbedMetrics {
+			wg.Add(1)
+			go postHostMetricWorker(wg, client, hch)
+		} else {
+			go dumpHostMetricWorker(hch)
+		}
+	}
+
+	if len(conf.Aggregates) > 0 {
+		if conf.PostAggregatedMetrics {
+			wg.Add(1)
+			go postServiceMetricWorker(wg, client, sch)
+		} else {
+			go dumpServiceMetricWorker(sch)
+		}
 	}
 
 	ticker := time.NewTicker(ProbeInterval)
@@ -56,7 +74,11 @@ func Run(ctx context.Context, wg *sync.WaitGroup, configPath string, once bool) 
 		var wg2 sync.WaitGroup
 		for _, pd := range conf.Probes {
 			wg2.Add(1)
-			go runProbes(ctx, pd, client, ch, &wg2)
+			go runProbes(ctx, pd, client, hch, &wg2)
+		}
+		for _, ag := range conf.Aggregates {
+			wg2.Add(1)
+			go runAggregates(ctx, ag, client, sch, &wg2)
 		}
 		wg2.Wait()
 		if once {
@@ -87,7 +109,7 @@ func Run(ctx context.Context, wg *sync.WaitGroup, configPath string, once bool) 
 func runProbes(ctx context.Context, pd *ProbeDefinition, client *mackerel.Client, ch chan HostMetric, wg *sync.WaitGroup) {
 	defer wg.Done()
 	log.Printf(
-		"[debug] finding hosts service:%s roles:%s statuses:%v",
+		"[debug] probes finding hosts service:%s roles:%s statuses:%v",
 		pd.Service,
 		pd.Roles,
 		pd.Statuses,
@@ -98,10 +120,10 @@ func runProbes(ctx context.Context, pd *ProbeDefinition, client *mackerel.Client
 		Statuses: pd.Statuses,
 	})
 	if err != nil {
-		log.Println("[error]", err)
+		log.Println("[error] probes find host failed", err)
 		return
 	}
-	log.Printf("[debug] %d hosts found", len(hosts))
+	log.Printf("[debug] probes %d hosts found", len(hosts))
 	if len(hosts) == 0 {
 		return
 	}
@@ -114,7 +136,7 @@ func runProbes(ctx context.Context, pd *ProbeDefinition, client *mackerel.Client
 	var wg2 sync.WaitGroup
 	for _, host := range hosts {
 		time.Sleep(spawnInterval)
-		log.Printf("[debug] preparing host id:%s name:%s", host.ID, host.Name)
+		log.Printf("[debug] probes preparing host id:%s name:%s", host.ID, host.Name)
 		wg2.Add(1)
 		go func(host *mackerel.Host) {
 			lock()
@@ -135,7 +157,132 @@ func runProbes(ctx context.Context, pd *ProbeDefinition, client *mackerel.Client
 	wg2.Wait()
 }
 
-func postMetricWorker(wg *sync.WaitGroup, client *mackerel.Client, ch chan HostMetric) {
+func runAggregates(ctx context.Context, ag *AggregateDefinition, client *mackerel.Client, ch chan ServiceMetric, wg *sync.WaitGroup) {
+	defer wg.Done()
+	log.Printf(
+		"[debug] aggregates finding hosts service:%s roles:%s statuses:%v",
+		ag.Service,
+		ag.Roles,
+		ag.Statuses,
+	)
+	hosts, err := client.FindHosts(&mackerel.FindHostsParam{
+		Service:  ag.Service,
+		Roles:    ag.Roles,
+		Statuses: ag.Statuses,
+	})
+	if err != nil {
+		log.Println("[error] aggregates find hosts failed", err)
+		return
+	}
+	log.Printf("[debug] aggregates %d hosts found", len(hosts))
+	if len(hosts) == 0 {
+		return
+	}
+	hostIDs := make([]string, 0, len(hosts))
+	for _, h := range hosts {
+		hostIDs = append(hostIDs, h.ID)
+	}
+	metricNames := make([]string, 0, len(ag.Metrics))
+	for _, m := range ag.Metrics {
+		metricNames = append(metricNames, m.Name)
+	}
+
+	log.Printf("[debug] fetching latest metrics hosts:%v metrics:%v", hostIDs, metricNames)
+	latest, err := fetchLatestMetricValues(client, hostIDs, metricNames)
+	if err != nil {
+		log.Printf("[error] fetch latest metrics failed. %s hosts:%v metrics:%v", err, hostIDs, metricNames)
+		return
+	}
+
+	now := time.Now()
+	for _, mc := range ag.Metrics {
+		name := mc.Name
+		var timestamp float64
+		values := []float64{}
+		for hostID, metrics := range latest {
+			if _v, ok := metrics[name]; ok {
+				if _v == nil {
+					log.Printf("[debug] latest %s:%s is not found", hostID, name)
+					continue
+				}
+				v, ok := _v.Value.(float64)
+				if !ok {
+					log.Printf("[warn] latest %s:%s = %v is not a float64 value", hostID, name, _v)
+					continue
+				}
+				ts := time.Unix(_v.Time, 0)
+				log.Printf("[debug] latest %s:%s:%d = %f", hostID, name, _v.Time, v)
+				if ts.After(now.Add(metricTimeMargin)) {
+					values = append(values, v)
+					timestamp = math.Max(float64(_v.Time), timestamp)
+				} else {
+					log.Printf("[warn] latest %s:%s at %s is outdated", hostID, name, ts)
+				}
+			}
+		}
+		if len(values) == 0 {
+			continue
+		}
+
+		for _, output := range mc.Outputs {
+			var value float64
+			switch strings.ToLower(output.Func) {
+			case "sum":
+				value = sum(values)
+			case "min":
+				value = min(values)
+			case "max":
+				value = max(values)
+			case "avg", "average":
+				value = avg(values)
+			case "count":
+				value = count(values)
+			}
+			log.Printf("[debug] aggregates %s(%s)=%f -> %s:%s",
+				output.Func, name,
+				value,
+				ag.Service, output.Name,
+			)
+			ch <- ServiceMetric{
+				Service:   ag.Service,
+				Name:      output.Name,
+				Value:     value,
+				Timestamp: time.Unix(int64(timestamp), 0),
+			}
+		}
+	}
+}
+
+func sum(values []float64) (value float64) {
+	for _, v := range values {
+		value = value + v
+	}
+	return
+}
+
+func min(values []float64) (value float64) {
+	for _, v := range values {
+		value = math.Min(v, value)
+	}
+	return
+}
+
+func max(values []float64) (value float64) {
+	for _, v := range values {
+		value = math.Max(v, value)
+	}
+	return
+}
+
+func count(values []float64) (value float64) {
+	return float64(len(values))
+}
+
+func avg(values []float64) (value float64) {
+	return sum(values) / count(values)
+}
+
+func postHostMetricWorker(wg *sync.WaitGroup, client *mackerel.Client, ch chan HostMetric) {
 	defer wg.Done()
 	ticker := time.NewTicker(10 * time.Second)
 	mvs := make([]*mackerel.HostMetricValue, 0, PostMetricBufferLength)
@@ -171,10 +318,21 @@ func postMetricWorker(wg *sync.WaitGroup, client *mackerel.Client, ch chan HostM
 	}
 }
 
-func dumpMetricWorker(ch chan HostMetric) {
+func postServiceMetricWorker(wg *sync.WaitGroup, client *mackerel.Client, ch chan ServiceMetric) {
+	defer wg.Done()
+}
+
+func dumpHostMetricWorker(ch chan HostMetric) {
 	for m := range ch {
 		b, _ := json.Marshal(m.HostMetricValue())
-		log.Println("[debug]", string(b))
+		log.Printf("[info] %s %s", m.HostID, b)
+	}
+}
+
+func dumpServiceMetricWorker(ch chan ServiceMetric) {
+	for m := range ch {
+		b, _ := json.Marshal(m.MetricValue())
+		log.Printf("[info] %s %s", m.Service, b)
 	}
 }
 

--- a/maprobe.go
+++ b/maprobe.go
@@ -243,35 +243,6 @@ func runAggregates(ctx context.Context, ag *AggregateDefinition, client *mackere
 	}
 }
 
-func sum(values []float64) (value float64) {
-	for _, v := range values {
-		value = value + v
-	}
-	return
-}
-
-func min(values []float64) (value float64) {
-	for _, v := range values {
-		value = math.Min(v, value)
-	}
-	return
-}
-
-func max(values []float64) (value float64) {
-	for _, v := range values {
-		value = math.Max(v, value)
-	}
-	return
-}
-
-func count(values []float64) (value float64) {
-	return float64(len(values))
-}
-
-func avg(values []float64) (value float64) {
-	return sum(values) / count(values)
-}
-
 func postHostMetricWorker(wg *sync.WaitGroup, client *mackerel.Client, ch chan HostMetric) {
 	log.Println("[info] starting postHostMetricWorker")
 	defer wg.Done()
@@ -320,7 +291,10 @@ func postServiceMetricWorker(wg *sync.WaitGroup, client *mackerel.Client, ch cha
 		case m, cont := <-ch:
 			if cont {
 				if math.IsNaN(m.Value) {
-					log.Printf("[warn] %s:%s value NaN is not supported by Mackerel")
+					log.Printf(
+						"[warn] %s:%s value NaN is not supported by Mackerel",
+						m.Service, m.Name,
+					)
 					continue
 				} else {
 					mvsMap[m.Service] = append(mvsMap[m.Service], m.MetricValue())

--- a/ping.go
+++ b/ping.go
@@ -75,8 +75,8 @@ func (p *PingProbe) String() string {
 	return string(b)
 }
 
-func (p *PingProbe) Run(ctx context.Context) (Metrics, error) {
-	var ms Metrics
+func (p *PingProbe) Run(ctx context.Context) (HostMetrics, error) {
+	var ms HostMetrics
 
 	log.Printf("[debug] run ping to %s", p.Address)
 	pinger := fping.NewPinger()

--- a/probe.go
+++ b/probe.go
@@ -13,7 +13,7 @@ import (
 )
 
 type Probe interface {
-	Run(ctx context.Context) (Metrics, error)
+	Run(ctx context.Context) (HostMetrics, error)
 	HostID() string
 	MetricName(string) string
 }
@@ -22,9 +22,9 @@ type ProbeConfig interface {
 	GenerateProbe(host *mackerel.Host) (Probe, error)
 }
 
-type Metrics []Metric
+type HostMetrics []HostMetric
 
-func (ms Metrics) String() string {
+func (ms HostMetrics) String() string {
 	var b strings.Builder
 	for _, m := range ms {
 		b.WriteString(m.String())
@@ -33,14 +33,14 @@ func (ms Metrics) String() string {
 	return b.String()
 }
 
-type Metric struct {
+type HostMetric struct {
 	HostID    string
 	Name      string
 	Value     float64
 	Timestamp time.Time
 }
 
-func (m Metric) HostMetricValue() *mackerel.HostMetricValue {
+func (m HostMetric) HostMetricValue() *mackerel.HostMetricValue {
 	mv := &mackerel.MetricValue{
 		Name:  "custom." + m.Name,
 		Time:  m.Timestamp.Unix(),
@@ -52,7 +52,7 @@ func (m Metric) HostMetricValue() *mackerel.HostMetricValue {
 	}
 }
 
-func (m Metric) String() string {
+func (m HostMetric) String() string {
 	return fmt.Sprintf("%s\t%f\t%d", m.Name, m.Value, m.Timestamp.Unix())
 }
 
@@ -89,8 +89,8 @@ func expandPlaceHolder(src string, host *mackerel.Host) (string, error) {
 	return b.String(), err
 }
 
-func newMetric(p Probe, name string, value float64) Metric {
-	return Metric{
+func newMetric(p Probe, name string, value float64) HostMetric {
+	return HostMetric{
 		HostID:    p.HostID(),
 		Name:      p.MetricName(name),
 		Value:     value,

--- a/tcp.go
+++ b/tcp.go
@@ -113,7 +113,7 @@ func (p *TCPProbe) String() string {
 	return string(b)
 }
 
-func (p *TCPProbe) Run(ctx context.Context) (ms Metrics, err error) {
+func (p *TCPProbe) Run(ctx context.Context) (ms HostMetrics, err error) {
 	var ok bool
 	start := time.Now()
 	defer func() {

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -32,3 +32,17 @@ probes:
       expect_pattern: "ok"
       no_check_certificate: true
 
+aggregates:
+  - service: prod
+    role: web
+    metrics:
+      - name: custom.nginx.requests.requests
+        outputs:
+          - func: sum
+            name: custom.nginx.requests.sum_requests
+          - func: avg
+            name: custom.nginx.requests.avg_requests
+      - name: custom.nginx.connections.connections
+        outputs:
+          - func: avg
+            name: custom.nginx.connections.avg_connections


### PR DESCRIPTION
Add aggregate feature.

aggregates works as below.

1. Fetch hosts information from Mackerel API.
   - Filtered service and role.
1. For each hosts, fetch specified host metrics to calculates these metrics by functions.
1. Post theses aggregated metrics as Mackerel service metrics.
1. Iterates these processes each 60 sec.

It is useful for monitoring the long span aggregated host metrics.