### PR TITLE
Accept an array value for probes[].command.command

### DIFF
--- a/client.go
+++ b/client.go
@@ -28,7 +28,7 @@ func fetchLatestMetricValues(client *mackerel.Client, hostIDs []string, metricNa
 				log.Printf("[trace] fetching host metric values: %s %s from %s to %s", hostID, metricName, from, to)
 				mvs, err := client.FetchHostMetricValues(hostID, metricName, from.Unix(), to.Unix())
 				if err != nil {
-					log.Printf("[warn] failed to fetch host metric values: %s %s from %s to %s", hostID, metricName, from, to)
+					log.Printf("[warn] failed to fetch host metric values: %s %s %s from %s to %s", err, hostID, metricName, from, to)
 					return
 				}
 				if len(mvs) == 0 {

--- a/test/command.yaml
+++ b/test/command.yaml
@@ -1,0 +1,7 @@
+apikey: dummy
+probes:
+  - command:
+      command: ["./test/command-plugin", "{{ .Host.ID }}"]
+      graph_defs: true
+  - command:
+      command: "./test/command-plugin {{ .Host.ID }}"

--- a/test/command_fail.yaml
+++ b/test/command_fail.yaml
@@ -1,0 +1,6 @@
+apikey: dummy
+probes:
+  - command:
+      command:
+  - command:
+      command: []


### PR DESCRIPTION
`command` accepts both a single string value and an array value.
 If an array value is passed, these are not processed by shell.
