### PR TITLE
Command runs via sh -c when passed a single string.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -124,14 +124,6 @@
   revision = "458a40e9ccd85aa429f2894ea94f94d35bebd49f"
 
 [[projects]]
-  digest = "1:477cce5379198d3b8230b5c0961c61fcd1b337371cda81318e89a109245d83cb"
-  name = "github.com/mattn/go-shellwords"
-  packages = ["."]
-  pruneopts = ""
-  revision = "02e3cf038dcea8290e44424da473dd12be796a8a"
-  version = "v1.0.3"
-
-[[projects]]
   digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
   name = "github.com/pkg/errors"
   packages = ["."]
@@ -191,7 +183,6 @@
     "github.com/google/gops/agent",
     "github.com/hashicorp/logutils",
     "github.com/mackerelio/mackerel-client-go",
-    "github.com/mattn/go-shellwords",
     "github.com/pkg/errors",
     "github.com/tatsushid/go-fastping",
     "gopkg.in/alecthomas/kingpin.v2",

--- a/command.go
+++ b/command.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	mackerel "github.com/mackerelio/mackerel-client-go"
-	shellwords "github.com/mattn/go-shellwords"
 	"github.com/pkg/errors"
 )
 
@@ -76,10 +75,7 @@ func (pc *CommandProbeConfig) GenerateProbe(host *mackerel.Host, client *mackere
 	}
 
 	if len(p.Command) == 1 && strings.Contains(p.Command[0], " ") {
-		p.Command, err = shellwords.Parse(p.Command[0])
-		if err != nil {
-			return nil, errors.Wrap(err, "parse command failed")
-		}
+		p.Command = []string{"sh", "-c", p.Command[0]}
 	}
 
 	if p.Timeout == 0 {

--- a/test/command.yaml
+++ b/test/command.yaml
@@ -4,4 +4,4 @@ probes:
       command: ["./test/command-plugin", "{{ .Host.ID }}"]
       graph_defs: true
   - command:
-      command: "./test/command-plugin {{ .Host.ID }}"
+      command: "./test/command-plugin 'XXX{{ .Host.ID }}' | sed -e 's/XXX//'"


### PR DESCRIPTION
This behavior becomes same as mackerel-agent.