### PR TITLE
Expand environment variable in service, role(s), statues

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Defaults of `--config` and `--log-level` will be overrided from envrionment vari
 ```yaml
 post_probed_metrics: false   # when false, do not post host metrics to Mackerel. only dump to [info] log.
 probes:
-  - service: production
+  - service: '{{ env "SERVICE" }}'   # expand environment variable
     role: server
     ping:
       address: '{{ .Host.IPAddresses.eth0 }}'

--- a/config.go
+++ b/config.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -22,8 +21,6 @@ import (
 
 type Config struct {
 	location string
-
-	APIKey string `yaml:"apikey"`
 
 	Probes            []*ProbeDefinition `yaml:"probes"`
 	PostProbedMetrics bool               `yaml:"post_probed_metrics"`
@@ -109,7 +106,6 @@ func (pd *ProbeDefinition) GenerateProbes(host *mackerel.Host, client *mackerel.
 func LoadConfig(location string) (*Config, string, error) {
 	c := &Config{
 		location:              location,
-		APIKey:                os.Getenv("MACKEREL_APIKEY"),
 		PostProbedMetrics:     true,
 		PostAggregatedMetrics: true,
 	}
@@ -147,9 +143,6 @@ func (c *Config) initialize() error {
 }
 
 func (c *Config) validate() error {
-	if c.APIKey == "" {
-		return errors.New("no API Key")
-	}
 	if o := c.ProbeOnly; o != nil {
 		log.Println("[warn] configuration probe_only is not deprecated. use post_probed_metrics")
 		c.PostProbedMetrics = !*o

--- a/config_test.go
+++ b/config_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 var testConfigExpected = &Config{
-	APIKey:            "DUMMY",
 	PostProbedMetrics: false,
 	Probes: []*ProbeDefinition{
 		&ProbeDefinition{

--- a/maprobe.go
+++ b/maprobe.go
@@ -113,10 +113,20 @@ func runProbes(ctx context.Context, pd *ProbeDefinition, client *mackerel.Client
 		pd.Roles,
 		pd.Statuses,
 	)
+	roles := make([]string, 0, len(pd.Roles))
+	for _, role := range pd.Roles {
+		roles = append(roles, role.String())
+	}
+
+	statuses := make([]string, 0, len(pd.Statuses))
+	for _, status := range pd.Statuses {
+		statuses = append(statuses, status.String())
+	}
+
 	hosts, err := client.FindHosts(&mackerel.FindHostsParam{
-		Service:  pd.Service,
-		Roles:    pd.Roles,
-		Statuses: pd.Statuses,
+		Service:  pd.Service.String(),
+		Roles:    roles,
+		Statuses: statuses,
 	})
 	if err != nil {
 		log.Println("[error] probes find host failed", err)

--- a/maprobe.go
+++ b/maprobe.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log"
 	"math"
+	"os"
 	"sync"
 	"time"
 
@@ -42,7 +43,7 @@ func Run(ctx context.Context, wg *sync.WaitGroup, configPath string, once bool) 
 		return err
 	}
 	log.Println("[debug]", conf.String())
-	client := mackerel.NewClient(conf.APIKey)
+	client := mackerel.NewClient(os.Getenv("MACKEREL_APIKEY"))
 
 	hch := make(chan HostMetric, PostMetricBufferLength*10)
 	defer close(hch)

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -18,7 +18,7 @@ probes:
       expect_pattern: "^VERSION "
       timeout: 3s
 
-  - service: prod
+  - service: '{{ must_env "SERVICE" }}'
     role: ALB
     http:
       url: "{{ .metadata.probe.url }}?service={{ env `SERVICE` }}"

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -1,4 +1,3 @@
-apikey: DUMMY
 probes:
   - service: '{{ must_env "SERVICE" }}'
     role: EC2

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -1,6 +1,6 @@
 apikey: DUMMY
 probes:
-  - service: prod
+  - service: '{{ must_env "SERVICE" }}'
     role: EC2
     statuses:
       - working
@@ -11,7 +11,7 @@ probes:
       timeout: 5s
 
   - service: prod
-    role: NLB
+    role: '{{ must_env "SERVICE" }}-NLB'
     tcp:
       host: "{{ .customIdentifier }}"
       port: 11211
@@ -22,7 +22,7 @@ probes:
   - service: prod
     role: ALB
     http:
-      url: "{{ .metadata.probe.url }}"
+      url: "{{ .metadata.probe.url }}?service={{ env `SERVICE` }}"
       method: POST
       headers:
         "User-Agent": "maprobe/0.0.1"


### PR DESCRIPTION
This PR enables to expand environment variable in configuration item parameter such of service, role(s), statuses.
