### PR TITLE
A probe context has context.Background() as parent context.

### DIFF
--- a/command.go
+++ b/command.go
@@ -113,7 +113,7 @@ func (p *CommandProbe) String() string {
 }
 
 func (p *CommandProbe) Run(ctx context.Context) (ms HostMetrics, err error) {
-	ctx, cancel := context.WithTimeout(ctx, p.Timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), p.Timeout)
 	defer cancel()
 
 	var cmd *exec.Cmd

--- a/http.go
+++ b/http.go
@@ -126,7 +126,7 @@ func (p *HTTPProbe) Run(ctx context.Context) (ms HostMetrics, err error) {
 		log.Println("[trace]", ms.String())
 	}()
 
-	ctx, cancel := context.WithTimeout(ctx, p.Timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), p.Timeout)
 	defer cancel()
 
 	req, err := http.NewRequest(p.Method, p.URL, strings.NewReader(p.Body))

--- a/tcp.go
+++ b/tcp.go
@@ -128,7 +128,7 @@ func (p *TCPProbe) Run(ctx context.Context) (ms HostMetrics, err error) {
 		log.Println("[debug]", ms.String())
 	}()
 
-	ctx, cancel := context.WithTimeout(ctx, p.Timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), p.Timeout)
 	defer cancel()
 
 	addr := net.JoinHostPort(p.Host, p.Port)


### PR DESCRIPTION
Even if maprobe get a signal, running probes should not be canceled.