### PR TITLE
Emit zero value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,10 @@ lint: setup
 	golint -set_exit_status ./...
 
 dist: setup
-	goxz -pv=$(LATEST_TAG) -os=darwin,linux -build-ldflags="-w -s" -arch=amd64 -d=dist -z ./cmd/maprobe
+	CGO_ENABLED=0 goxz -pv=$(LATEST_TAG) -os=darwin,linux -build-ldflags="-w -s" -arch=amd64 -d=dist -z ./cmd/maprobe
 
 clean:
 	rm -fr dist/* test/config.*.yaml cmd/maprobe/maprobe
 
 release: dist
 	ghr -u fujiwara -r maprobe $(LATEST_TAG) dist/
-

--- a/client.go
+++ b/client.go
@@ -25,7 +25,13 @@ func fetchLatestMetricValues(client *mackerel.Client, hostIDs []string, metricNa
 					<-clientSem
 					wg.Done()
 				}()
-				log.Printf("[trace] fetching host metric values: %s %s from %s to %s", hostID, metricName, from, to)
+				log.Printf(
+					"[trace] fetching host metric values: %s %s from %s to %s",
+					hostID,
+					metricName,
+					from.Format(time.RFC3339),
+					to.Format(time.RFC3339),
+				)
 				mvs, err := client.FetchHostMetricValues(hostID, metricName, from.Unix(), to.Unix())
 				if err != nil {
 					log.Printf("[warn] failed to fetch host metric values: %s %s %s from %s to %s", err, hostID, metricName, from, to)

--- a/config.go
+++ b/config.go
@@ -245,8 +245,9 @@ type MetricConfig struct {
 }
 
 type OutputConfig struct {
-	Func exString `yaml:"func"`
-	Name exString `yaml:"name"`
+	Func     exString `yaml:"func"`
+	Name     exString `yaml:"name"`
+	EmitZero bool     `yaml:"emit_zero"`
 
 	calc func([]float64) float64
 }


### PR DESCRIPTION
Add aggregates.metrics[].output.emit_zero configuration.

When hosts or metrics are not found,  post value 0 to Mackerel.