### PR TITLE
Add median function for aggregates

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ Following functions are available to aggregate host metrics.
 - min / minimum
 - max / maximum
 - avg / average
+- median
 - count
 
 ## Author

--- a/calc.go
+++ b/calc.go
@@ -1,6 +1,9 @@
 package maprobe
 
-import "math"
+import (
+	"math"
+	"sort"
+)
 
 func sum(values []float64) (value float64) {
 	for _, v := range values {
@@ -29,4 +32,16 @@ func count(values []float64) (value float64) {
 
 func avg(values []float64) (value float64) {
 	return sum(values) / count(values)
+}
+
+func median(values []float64) (value float64) {
+	len := len(values)
+
+	sort.Float64s(values)
+
+	if len%2 == 0 {
+		return (values[len/2-1] + values[len/2]) / 2.0
+	}
+	return values[(len-1)/2]
+
 }

--- a/config.go
+++ b/config.go
@@ -168,6 +168,8 @@ func (c *Config) validate() error {
 					oc.calc = max
 				case "avg", "average":
 					oc.calc = avg
+				case "median":
+					oc.calc = median
 				case "count":
 					oc.calc = count
 				default:

--- a/config_test.go
+++ b/config_test.go
@@ -80,6 +80,10 @@ var testConfigExpected = &Config{
 							Func: exString{"avg"},
 							Name: exString{"custom.nginx.connections.avg_connections"},
 						},
+						&OutputConfig{
+							Func: exString{"median"},
+							Name: exString{"custom.nginx.connections.median_connections"},
+						},
 					},
 				},
 			},

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -45,3 +45,5 @@ aggregates:
         outputs:
           - func: avg
             name: custom.nginx.connections.avg_connections
+          - func: median
+            name: custom.nginx.connections.median_connections


### PR DESCRIPTION
We can choose whether to average out or ignore outlier host metrics.