### PR TITLE
add workflow to build and publish arm64 container image and binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,16 @@ jobs:
           make dist
           make release
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: docker
         run: |
           export TAG=$(echo $GITHUB_REF | cut -d/ -f3)
           echo $DOCKER_TOKEN | docker login -u fujiwara --password-stdin
-          make docker-build-all
-          make docker-push-all
+          make docker-build-push-all
         env:
           DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,11 @@ docker-build/%:
 
 docker-build-all: docker-build/bullseye-slim docker-build/buster-slim docker-build/mackerel-plugins docker-build/plain
 
+docker-push/%:
+	docker push fujiwara/maprobe:${TAG}-$*
+
+docker-push-all: docker-push/bullseye-slim docker-push/buster-slim docker-push/mackerel-plugins docker-push/plain
+
 docker-build-push/%:
 	docker buildx build --build-arg version=${TAG} \
       	--platform=linux/amd64,linux/arm64 \

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ lint: setup
 	golint -set_exit_status ./...
 
 dist: setup
-	CGO_ENABLED=0 goxz -pv=$(LATEST_TAG) -os=darwin,linux -build-ldflags="-w -s" -arch=amd64 -d=dist -z ./cmd/maprobe
+	CGO_ENABLED=0 goxz -pv=$(LATEST_TAG) -os=darwin,linux -build-ldflags="-w -s" -arch=amd64,arm64 -d=dist -z ./cmd/maprobe
 
 clean:
 	rm -fr dist/* test/config.*.yaml cmd/maprobe/maprobe
@@ -44,7 +44,12 @@ docker-build/%:
 
 docker-build-all: docker-build/bullseye-slim docker-build/buster-slim docker-build/mackerel-plugins docker-build/plain
 
-docker-push/%:
-	docker push fujiwara/maprobe:${TAG}-$*
+docker-build-push/%:
+	docker buildx build --build-arg version=${TAG} \
+      	--platform=linux/amd64,linux/arm64 \
+      	-t maprobe:${TAG}-$* \
+      	-f docker/$*/Dockerfile \
+      	--push \
+      	.
 
-docker-push-all: docker-push/bullseye-slim docker-push/buster-slim docker-push/mackerel-plugins docker-push/plain
+docker-build-push-all: docker-build-push/bullseye-slim docker-build-push/buster-slim docker-build-push/mackerel-plugins docker-build-push/plain

--- a/docker/bullseye-slim/Dockerfile
+++ b/docker/bullseye-slim/Dockerfile
@@ -1,5 +1,10 @@
-FROM golang:1.18.4-buster AS build-env
+FROM --platform=${BUILDPLATFORM} golang:1.18.4-buster AS build-env
 
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV GOOS=${TARGETOS}
+ENV GOARCH=${TARGETARCH}
 ENV CGO_ENABLED=0
 ENV GO111MODULE=on
 RUN mkdir -p /go/src/github.com/fujiwara/maprobe

--- a/docker/buster-slim/Dockerfile
+++ b/docker/buster-slim/Dockerfile
@@ -1,5 +1,10 @@
-FROM golang:1.18.4-buster AS build-env
+FROM --platform=${BUILDPLATFORM} golang:1.18.4-buster AS build-env
 
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV GOOS=${TARGETOS}
+ENV GOARCH=${TARGETARCH}
 ENV CGO_ENABLED=0
 ENV GO111MODULE=on
 RUN mkdir -p /go/src/github.com/fujiwara/maprobe

--- a/docker/mackerel-plugins/Dockerfile
+++ b/docker/mackerel-plugins/Dockerfile
@@ -1,5 +1,10 @@
-FROM golang:1.18.4-buster AS build-env
+FROM --platform=${BUILDPLATFORM} golang:1.18.4-buster AS build-env
 
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV GOOS=${TARGETOS}
+ENV GOARCH=${TARGETARCH}
 ENV CGO_ENABLED=0
 ENV GO111MODULE=on
 RUN apt-get update && apt-get -y install sudo

--- a/docker/plain/Dockerfile
+++ b/docker/plain/Dockerfile
@@ -1,5 +1,10 @@
-FROM golang:1.18.4-buster AS build-env
+FROM --platform=${BUILDPLATFORM} golang:1.18.4-buster AS build-env
 
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV GOOS=${TARGETOS}
+ENV GOARCH=${TARGETARCH}
 ENV CGO_ENABLED=0
 ENV GO111MODULE=on
 RUN mkdir -p /go/src/github.com/fujiwara/maprobe


### PR DESCRIPTION
I want to use maprobe container on linux/arm64.
But maprobe is not publishing arm64 container images.

So I created workflow to build and publish multi-platform images with Docker buildx.

And I added arm64 binary releases too.
