### PR TITLE
Backquotes were missing on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ command:
     - "-option=foo"
   timeout: "5s"                      # Seconds of command timeout (default 15)
   graph_defs: true                   # Post graph definitions to Mackerel (default false)
+```
 
 Command probe handles command's output as host metric.
 


### PR DESCRIPTION
In the middle of README.md, the backquote for syntax highlighting was missing, and the rendering result was broken, so I fixed it.