### PR TITLE
Fix AggregatedMetrics not being posted to Mackerel

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -3,7 +3,6 @@ package maprobe
 type Channels struct {
 	ServiceMetrics    chan ServiceMetric
 	HostMetrics       chan HostMetric
-	AggregatedMetrics chan ServiceMetric
 	OtelMetrics       chan Metric
 	Destination       *DestinationConfig
 }
@@ -12,7 +11,6 @@ func NewChannels(dst *DestinationConfig) *Channels {
 	chs := Channels{
 		ServiceMetrics:    make(chan ServiceMetric, PostMetricBufferLength*10),
 		HostMetrics:       make(chan HostMetric, PostMetricBufferLength*10),
-		AggregatedMetrics: make(chan ServiceMetric, PostMetricBufferLength*10),
 		OtelMetrics:       make(chan Metric, PostMetricBufferLength*10),
 		Destination:       dst,
 	}
@@ -39,7 +37,7 @@ func (ch *Channels) SendHostMetric(m HostMetric) {
 
 func (ch *Channels) SendAggregatedMetric(m ServiceMetric) {
 	if ch.Destination.Mackerel.Enabled {
-		ch.AggregatedMetrics <- m
+		ch.ServiceMetrics <- m
 	}
 	// TODO: Otel Aggregated Metrics
 }
@@ -47,6 +45,5 @@ func (ch *Channels) SendAggregatedMetric(m ServiceMetric) {
 func (ch *Channels) Close() {
 	close(ch.ServiceMetrics)
 	close(ch.HostMetrics)
-	close(ch.AggregatedMetrics)
 	close(ch.OtelMetrics)
 }


### PR DESCRIPTION
Closes #33 

Aggregated metrics are now posted to Mackerel when `post_aggregated_metrics: true`.

The message for posting service metrics is `chs.ServiceMetrics`, so I used that, and since `chs.AggregatedMetrics` is no longer used, I deleted it.