### PR TITLE
metric name is required.

### DIFF
--- a/command.go
+++ b/command.go
@@ -287,9 +287,12 @@ func parseMetricLine(b string) (Metric, error) {
 		return Metric{}, errors.New("invalid metric format. insufficient columns")
 	}
 	name, value, timestamp := cols[0], cols[1], cols[2]
-	m := Metric{}
-	m.Name = name
-
+	if name == "" {
+		return Metric{}, errors.New("invalid metric format. name is empty")
+	}
+	m := Metric{
+		Name: name,
+	}
 	if v, err := strconv.ParseFloat(value, 64); err != nil {
 		return m, fmt.Errorf("invalid metric value: %s", value)
 	} else {

--- a/command.go
+++ b/command.go
@@ -159,14 +159,14 @@ func (p *CommandProbe) Run(_ context.Context) (ms Metrics, err error) {
 	scanner := bufio.NewScanner(stdout)
 
 	if err := cmd.Start(); err != nil {
-		return ms, errors.Wrap(err, "command execute failed")
+		return ms, errors.Wrap(err, fmt.Sprintf("command execute failed. %s", strings.Join(p.Command, " ")))
 	}
 
 	for scanner.Scan() {
 		log.Println("[trace]", scanner.Text())
 		m, err := parseMetricLine(scanner.Text())
 		if err != nil {
-			log.Println("[warn]", err)
+			log.Printf("[warn] %s failed to parse metric line. %s", strings.Join(p.Command, " "), err)
 			continue
 		}
 		if p.GraphDefs {

--- a/command_test.go
+++ b/command_test.go
@@ -2,6 +2,7 @@ package maprobe_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -83,5 +84,36 @@ func TestCommandFail(t *testing.T) {
 	c, _, err := maprobe.LoadConfig("test/command_fail.yaml")
 	if err == nil {
 		t.Errorf("must be failed but got %#v", c)
+	}
+}
+
+var ngInputs = []struct {
+	Title string
+	Line  string
+}{
+	{
+		Title: "invalid value",
+		Line:  strings.Join([]string{"test.foo", "x", "1523261168"}, "\t"),
+	},
+	{
+		Title: "invalid timestamp",
+		Line:  strings.Join([]string{"test.foo", "1", "x"}, "\t"),
+	},
+	{
+		Title: "Empty",
+		Line:  "",
+	},
+	{
+		Title: "No name",
+		Line:  strings.Join([]string{"", "1", "1523261168"}, "\t"),
+	},
+}
+
+func TestParseMetricLineNG(t *testing.T) {
+	for _, c := range ngInputs {
+		_, err := maprobe.ParseMetricLine(c.Line)
+		if err == nil {
+			t.Errorf("%s: must be failed", c.Title)
+		}
 	}
 }

--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,5 @@
+package maprobe
+
+var (
+	ParseMetricLine = parseMetricLine
+)


### PR DESCRIPTION
When an executed command returns invalid metric lines, Mackerel API cannot accept the metrics. The metric name is required.

```
[error] failed to post host metrics to Mackerel API request failed: Invalid Parameter: obj[0].name error.path.missing, obj[1].name error.path.missing, obj[2].name error.path.missing, obj[3].name error.path.missing, obj[4].name error.path.missing.
```