### PR TITLE
The version was fixed at 0.5.4, so I changed it to embed it at build time.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 export GO111MODULE := on
-LATEST_TAG := $(shell git describe --abbrev=0 --tags)
+LATEST_TAG := $(shell git describe --abbrev=0 --tagsgit describe --abbrev=0 --tags)
 TAG ?= latest
 
 .PHONY: setup setup_ci test lint dist clean release
@@ -28,7 +28,7 @@ lint: setup
 	golint -set_exit_status ./...
 
 dist: setup
-	CGO_ENABLED=0 goxz -pv=$(LATEST_TAG) -os=darwin,linux -build-ldflags="-w -s" -arch=amd64,arm64 -d=dist -z ./cmd/maprobe
+	CGO_ENABLED=0 goxz -pv=$(LATEST_TAG) -os=darwin,linux -build-ldflags="-w -s -X github.com/fujiwara/maprobe.Version=$(LATEST_TAG)" -arch=amd64,arm64 -d=dist -z ./cmd/maprobe
 
 clean:
 	rm -fr dist/* test/config.*.yaml cmd/maprobe/maprobe

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 export GO111MODULE := on
-LATEST_TAG := $(shell git describe --abbrev=0 --tagsgit describe --abbrev=0 --tags)
+LATEST_TAG := $(shell git describe --abbrev=0 --tags)
 TAG ?= latest
 
 .PHONY: setup setup_ci test lint dist clean release

--- a/maprobe.go
+++ b/maprobe.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	Version                = "0.5.4"
+	Version                = "HEAD"
 	MaxConcurrency         = 100
 	MaxClientConcurrency   = 5
 	PostMetricBufferLength = 100


### PR DESCRIPTION
When I downloaded the Docker image and checked the version, the container was v0.7.2, but the binary version information was 0.5.4.

So, when I checked the source, it was a fixed string, so I created a PR that would be embedded during build.

```shell
$ docker run --rm -it   fujiwara/maprobe:v0.7.2-mackerel-plugins
Unable to find image 'fujiwara/maprobe:v0.7.2-mackerel-plugins' locally
v0.7.2-mackerel-plugins: Pulling from fujiwara/maprobe
f109bca8a22f: Already exists 
b97c07a0b5f2: Already exists 
bbf6bf1d1fed: Already exists 
22e8290fd681: Already exists 
ed24ae6b2512: Already exists 
Digest: sha256:997ee7955e64c6ed1aa24fbae9ed09b9a030d1247333d281a4f9a595786dae76
Status: Downloaded newer image for fujiwara/maprobe:v0.7.2-mackerel-plugins
2024/05/13 03:00:26 [info] maprobe 0.5.4
usage: maprobe [<flags>] <command> [<args> ...]

Flags:
  --help              Show context-sensitive help (also try --help-long and --help-man).
  --log-level="info"  log level
  --gops              enable gops agent

Commands:
  help [<command>...]
    Show help.

  version
    Show version

  agent [<flags>]
    Run agent

  once [<flags>]
    Run once

  lambda [<flags>]
    Run on AWS Lambda like once mode

  ping [<flags>] <address>
    Run ping probe

  tcp [<flags>] <host> <port>
    Run TCP probe

  http [<flags>] <url>
    Run HTTP probe

  firehose-endpoint [<flags>]
    Run Firehose HTTP endpoint
```