### PR TITLE
use the latest patch version of go

### DIFF
--- a/docker/bookworm-slim/Dockerfile
+++ b/docker/bookworm-slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} golang:1.24.1-bookworm AS build-env
+FROM --platform=${BUILDPLATFORM} golang:1.24-bookworm AS build-env
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/docker/bullseye-slim/Dockerfile
+++ b/docker/bullseye-slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} golang:1.24.1-bullseye AS build-env
+FROM --platform=${BUILDPLATFORM} golang:1.24-bullseye AS build-env
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/docker/mackerel-plugins/Dockerfile
+++ b/docker/mackerel-plugins/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} golang:1.24.1-bookworm AS build-env
+FROM --platform=${BUILDPLATFORM} golang:1.24-bookworm AS build-env
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/docker/plain/Dockerfile
+++ b/docker/plain/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} golang:1.24.1-bookworm AS build-env
+FROM --platform=${BUILDPLATFORM} golang:1.24-bookworm AS build-env
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
This pull request updates the base Go image versions in several Dockerfiles to use `golang:1.24` instead of `golang:1.24.1`. This change ensures consistency across all Dockerfiles and aligns with the intended base image version.

### Dockerfile updates:

* [`docker/bookworm-slim/Dockerfile`](diffhunk://#diff-7a8f920c296ee33abd7059db34c6e1d0e896642101164a987ed9df71fb0da58cL1-R1): Changed the base image from `golang:1.24.1-bookworm` to `golang:1.24-bookworm`.
* [`docker/bullseye-slim/Dockerfile`](diffhunk://#diff-0f6761e504b1db47c21b6d5fa4833ee69f248960bd759e1f07026e1611d5965dL1-R1): Changed the base image from `golang:1.24.1-bullseye` to `golang:1.24-bullseye`.
* [`docker/mackerel-plugins/Dockerfile`](diffhunk://#diff-f647f8d51024955874456eadb01ba6c45cedf0e981e585be9aa9c195c47a4af7L1-R1): Changed the base image from `golang:1.24.1-bookworm` to `golang:1.24-bookworm`.
* [`docker/plain/Dockerfile`](diffhunk://#diff-d31c6141146959a47d80a66ced305eeedd332bcae121f7fca332dfee02fc0063L1-R1): Changed the base image from `golang:1.24.1-bookworm` to `golang:1.24-bookworm`.