### PR TITLE
Add structured logging with slog and OpenTelemetry metrics integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ destination:
     enabled: true
     endpoint: localhost:4317
     insecure: true
+    resource_attributes: # OpenTelemetry resource attributes (for all metrics)
+      deployment.environment.name: production
+    stats_attributes: # for maprobe internal metrics
+      service.name: maprobe
+      service.namespace: my-namespace
 ```
 
 Extra attributes can be added to metrics by `attributes` in probe configuration.

--- a/cli.go
+++ b/cli.go
@@ -1,0 +1,77 @@
+package maprobe
+
+import "time"
+
+// CLI defines the command line interface structure for Kong
+type CLI struct {
+	LogLevel    string `name:"log-level" help:"log level" default:"info" env:"LOG_LEVEL"`
+	LogFormat   string `name:"log-format" help:"log format (text|json)" default:"text" enum:"text,json" env:"LOG_FORMAT"`
+	GopsEnabled bool   `name:"gops" help:"enable gops agent" default:"false" env:"GOPS"`
+
+	Version          VersionCmd          `cmd:"" help:"Show version"`
+	Agent            AgentCmd            `cmd:"" help:"Run agent"`
+	Once             OnceCmd             `cmd:"" help:"Run once"`
+	Lambda           LambdaCmd           `cmd:"" help:"Run on AWS Lambda like once mode"`
+	Ping             PingCmd             `cmd:"" help:"Run ping probe"`
+	TCP              TCPCmd              `cmd:"" help:"Run TCP probe"`
+	HTTP             HTTPCmd             `cmd:"" help:"Run HTTP probe"`
+	FirehoseEndpoint FirehoseEndpointCmd `cmd:"" help:"Run Firehose HTTP endpoint"`
+}
+
+// VersionCmd represents the version command
+type VersionCmd struct{}
+
+// AgentCmd represents the agent command that runs continuously
+type AgentCmd struct {
+	Config               string `short:"c" help:"configuration file path or URL(http|s3)" env:"CONFIG"`
+	WithFirehoseEndpoint bool   `help:"run with firehose HTTP endpoint server"`
+	Port                 int    `help:"firehose HTTP endpoint listen port" default:"8080"`
+}
+
+// OnceCmd represents the once command that runs probes once and exits
+type OnceCmd struct {
+	Config string `short:"c" help:"configuration file path or URL(http|s3)" env:"CONFIG"`
+}
+
+// LambdaCmd represents the lambda command that runs on AWS Lambda
+type LambdaCmd struct {
+	Config string `short:"c" help:"configuration file path or URL(http|s3)" env:"CONFIG"`
+}
+
+// PingCmd represents the ping command for standalone ping probe
+type PingCmd struct {
+	Address string        `arg:"" help:"Hostname or IP address" required:""`
+	Count   int           `short:"c" help:"Iteration count"`
+	Timeout time.Duration `short:"t" help:"Timeout to ping response"`
+	HostID  string        `short:"i" help:"Mackerel host ID"`
+}
+
+// TCPCmd represents the TCP command for standalone TCP probe
+type TCPCmd struct {
+	Host               string        `arg:"" help:"Hostname or IP address" required:""`
+	Port               string        `arg:"" help:"Port number" required:""`
+	Send               string        `short:"s" help:"String to send to the server"`
+	Quit               string        `short:"q" help:"String to send server to initiate a clean close of the connection"`
+	Timeout            time.Duration `short:"t" help:"Timeout"`
+	ExpectPattern      string        `short:"e" name:"expect" help:"Regexp pattern to expect in server response"`
+	NoCheckCertificate bool          `short:"k" help:"Do not check certificate"`
+	HostID             string        `short:"i" help:"Mackerel host ID"`
+	TLS                bool          `help:"Use TLS"`
+}
+
+// HTTPCmd represents the HTTP command for standalone HTTP probe
+type HTTPCmd struct {
+	URL                string            `arg:"" help:"URL" required:""`
+	Method             string            `short:"m" help:"Request method" default:"GET"`
+	Body               string            `short:"b" help:"Request body"`
+	ExpectPattern      string            `short:"e" name:"expect" help:"Regexp pattern to expect in server response"`
+	Timeout            time.Duration     `short:"t" help:"Timeout"`
+	NoCheckCertificate bool              `short:"k" help:"Do not check certificate"`
+	Headers            map[string]string `short:"H" name:"header" help:"Request headers" placeholder:"Header: Value"`
+	HostID             string            `short:"i" help:"Mackerel host ID"`
+}
+
+// FirehoseEndpointCmd represents the firehose endpoint command for HTTP server
+type FirehoseEndpointCmd struct {
+	Port int `short:"p" help:"Listen port" default:"8080"`
+}

--- a/cmd/maprobe/main.go
+++ b/cmd/maprobe/main.go
@@ -43,7 +43,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "failed to create parser: %v\n", err)
 		os.Exit(1)
 	}
-	
+
 	kongCtx, err := parser.Parse(args[1:])
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to parse arguments: %v\n", err)
@@ -51,8 +51,8 @@ func main() {
 	}
 
 	// Setup structured logging
-	maprobe.SetupSlog(cli.LogLevel, cli.LogFormat)
-	
+	maprobe.SetupLogger(cli.LogLevel, cli.LogFormat)
+
 	slog.Info("maprobe", "version", maprobe.Version)
 
 	if cli.GopsEnabled {
@@ -99,7 +99,7 @@ func main() {
 
 	// Execute command
 	err = maprobe.Main(ctx, args)
-	
+
 	slog.Info("shutdown")
 	select {
 	case <-ctx.Done():

--- a/config.go
+++ b/config.go
@@ -39,9 +39,11 @@ type MackerelConfig struct {
 }
 
 type OtelConfig struct {
-	Enabled  bool   `yaml:"enabled"`
-	Endpoint string `yaml:"endpoint"`
-	Insecure bool   `yaml:"insecure"`
+	Enabled            bool              `yaml:"enabled"`
+	Endpoint           string            `yaml:"endpoint"`
+	Insecure           bool              `yaml:"insecure"`
+	ResourceAttributes map[string]string `yaml:"resource_attributes"`
+	StatsAttributes    map[string]string `yaml:"stats_attributes"`
 }
 
 type DestinationConfig struct {

--- a/go.mod
+++ b/go.mod
@@ -15,14 +15,17 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.49.0
 	github.com/fujiwara/ridge v0.13.0
 	github.com/fujiwara/sloghandler v0.0.5
+	github.com/fujiwara/sloghandler/otelmetrics v0.0.5
 	github.com/goccy/go-yaml v1.17.1
 	github.com/google/go-cmp v0.7.0
 	github.com/google/gops v0.3.28
 	github.com/mackerelio/mackerel-client-go v0.37.0
+	github.com/mattn/go-isatty v0.0.20
 	github.com/shogo82148/go-retry v1.3.1
 	github.com/tatsushid/go-fastping v0.0.0-20160109021039-d7bb493dee3e
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.36.0
+	go.opentelemetry.io/otel/metric v1.36.0
 	go.opentelemetry.io/otel/sdk v1.36.0
 	go.opentelemetry.io/otel/sdk/metric v1.36.0
 )
@@ -51,10 +54,8 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pires/go-proxyproto v0.8.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/otel/metric v1.36.0 // indirect
 	go.opentelemetry.io/otel/trace v1.36.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.6.0 // indirect
 	golang.org/x/net v0.40.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/fujiwara/ridge v0.13.0 h1:RdlfmQped/JQRdz8KdcKlGdt7NYSG+AwHFpPa7mc2YY
 github.com/fujiwara/ridge v0.13.0/go.mod h1:7IU7WrUos8KCYiNytBRCl9Q2x+XMdmeTZFWsVH33nhM=
 github.com/fujiwara/sloghandler v0.0.5 h1:YoWsgm9SrZfUsv5mu0vve7LNZ+6hJ5ZbGlI7rzZPKVA=
 github.com/fujiwara/sloghandler v0.0.5/go.mod h1:hX1CZHkFAiSXOaDhL3qSCcr1p1pL/gYPERs8+5E5nYc=
+github.com/fujiwara/sloghandler/otelmetrics v0.0.5 h1:AZZ+yFsL5m1g1ofBX1JV+8yXEVBL5vPe6fd2xAObkNc=
+github.com/fujiwara/sloghandler/otelmetrics v0.0.5/go.mod h1:IdrMcCRLeI0o9jXOGIFynJ8wx78yYD0zha0bO7T44lA=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -108,6 +110,8 @@ go.opentelemetry.io/otel v1.36.0 h1:UumtzIklRBY6cI/lllNZlALOF5nNIzJVb16APdvgTXg=
 go.opentelemetry.io/otel v1.36.0/go.mod h1:/TcFMXYjyRNh8khOAO9ybYkqaDBb/70aVwkNML4pP8E=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.36.0 h1:zwdo1gS2eH26Rg+CoqVQpEK1h8gvt5qyU5Kk5Bixvow=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.36.0/go.mod h1:rUKCPscaRWWcqGT6HnEmYrK+YNe5+Sw64xgQTOJ5b30=
+go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.36.0 h1:rixTyDGXFxRy1xzhKrotaHy3/KXdPhlWARrCgK+eqUY=
+go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.36.0/go.mod h1:dowW6UsM9MKbJq5JTz2AMVp3/5iW5I/TStsk8S+CfHw=
 go.opentelemetry.io/otel/metric v1.36.0 h1:MoWPKVhQvJ+eeXWHFBOPoBOi20jh6Iq2CcCREuTYufE=
 go.opentelemetry.io/otel/metric v1.36.0/go.mod h1:zC7Ks+yeyJt4xig9DEw9kuUFe5C3zLbVjV2PzT6qzbs=
 go.opentelemetry.io/otel/sdk v1.36.0 h1:b6SYIuLRs88ztox4EyrvRti80uXIFy+Sqzoh9kFULbs=

--- a/maprobe.go
+++ b/maprobe.go
@@ -82,12 +82,12 @@ func Run(ctx context.Context, wg *sync.WaitGroup, configPath string, once bool) 
 			return fmt.Errorf("failed to create OpenTelemetry meter exporter: %w", err)
 		}
 		defer exporter.Shutdown(ctx)
-		
+
 		// Setup logger with metrics
 		provider := modifyLoggerWithMetricExporter(exporter, resource, oc.StatsAttributes)
-		
+
 		// Create stats collector
-		statsCollector, err = NewStatsCollector(provider)
+		statsCollector, err = NewStatsCollector(provider, oc.StatsAttributes)
 		if err != nil {
 			slog.Error("failed to create stats collector", "error", err)
 			statsCollector = nil // Continue without stats metrics
@@ -659,6 +659,6 @@ func modifyLoggerWithMetricExporter(exporter otelsdkmetric.Exporter, resource *o
 
 	handler := otelmetrics.NewHandler(slog.Default().Handler(), counter)
 	slog.SetDefault(slog.New(handler))
-	
+
 	return provider
 }

--- a/stats.go
+++ b/stats.go
@@ -1,0 +1,153 @@
+package maprobe
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	otelattribute "go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
+	otelsdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+// StatsCollector manages maprobe internal metrics
+type StatsCollector struct {
+	meter                   otelmetric.Meter
+	probeConfigsGauge       otelmetric.Int64ObservableGauge
+	targetHostsGauge        otelmetric.Int64ObservableGauge
+	targetServicesGauge     otelmetric.Int64ObservableGauge
+	metricsCollectedCounter otelmetric.Int64Counter
+	probeExecutionsCounter  otelmetric.Int64Counter
+
+	// atomic values
+	currentProbeConfigs   int64
+	currentTargetHosts    int64
+	currentTargetServices int64
+}
+
+// SetProbeConfigs sets the number of configured probes
+func (s *StatsCollector) SetProbeConfigs(count int64) {
+	if s == nil {
+		return
+	}
+	atomic.StoreInt64(&s.currentProbeConfigs, count)
+}
+
+// SetTargetCounts sets the number of target hosts and services
+func (s *StatsCollector) SetTargetCounts(hosts, services int64) {
+	if s == nil {
+		return
+	}
+	atomic.StoreInt64(&s.currentTargetHosts, hosts)
+	atomic.StoreInt64(&s.currentTargetServices, services)
+}
+
+// RecordProbeExecution records a probe execution result
+func (s *StatsCollector) RecordProbeExecution(ctx context.Context, probe Probe, probeErr error) {
+	if s == nil || s.probeExecutionsCounter == nil {
+		return
+	}
+
+	probeType := getProbeType(probe)
+	status := "success"
+	if probeErr != nil {
+		status = "error"
+	}
+
+	s.probeExecutionsCounter.Add(ctx, 1,
+		otelmetric.WithAttributes(
+			otelattribute.String("status", status),
+			otelattribute.String("probe_type", probeType)))
+}
+
+// RecordMetricCollected records that a metric was collected
+func (s *StatsCollector) RecordMetricCollected(ctx context.Context) {
+	if s == nil || s.metricsCollectedCounter == nil {
+		return
+	}
+	s.metricsCollectedCounter.Add(ctx, 1)
+}
+
+// getProbeType returns the probe type string
+func getProbeType(probe Probe) string {
+	switch probe.(type) {
+	case *HTTPProbe:
+		return "http"
+	case *TCPProbe:
+		return "tcp"
+	case *PingProbe:
+		return "ping"
+	case *CommandProbe:
+		return "command"
+	default:
+		return "unknown"
+	}
+}
+
+// NewStatsCollector creates a new StatsCollector
+func NewStatsCollector(provider *otelsdkmetric.MeterProvider) (*StatsCollector, error) {
+	if provider == nil {
+		return nil, nil
+	}
+
+	s := &StatsCollector{
+		meter: provider.Meter("maprobe/stats"),
+	}
+
+	var err error
+	s.probeConfigsGauge, err = s.meter.Int64ObservableGauge(
+		"maprobe_probe_configs",
+		otelmetric.WithDescription("Number of configured probes"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create probe_configs gauge: %w", err)
+	}
+
+	s.targetHostsGauge, err = s.meter.Int64ObservableGauge(
+		"maprobe_target_hosts",
+		otelmetric.WithDescription("Number of target hosts"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create target_hosts gauge: %w", err)
+	}
+
+	s.targetServicesGauge, err = s.meter.Int64ObservableGauge(
+		"maprobe_target_services",
+		otelmetric.WithDescription("Number of target services"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create target_services gauge: %w", err)
+	}
+
+	s.metricsCollectedCounter, err = s.meter.Int64Counter(
+		"maprobe_metrics_collected_total",
+		otelmetric.WithDescription("Total number of metrics collected"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metrics_collected counter: %w", err)
+	}
+
+	s.probeExecutionsCounter, err = s.meter.Int64Counter(
+		"maprobe_probe_executions_total",
+		otelmetric.WithDescription("Total number of probe executions"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create probe_executions counter: %w", err)
+	}
+
+	// Register observable gauge callbacks
+	_, err = s.meter.RegisterCallback(
+		func(ctx context.Context, o otelmetric.Observer) error {
+			o.ObserveInt64(s.probeConfigsGauge, atomic.LoadInt64(&s.currentProbeConfigs))
+			o.ObserveInt64(s.targetHostsGauge, atomic.LoadInt64(&s.currentTargetHosts))
+			o.ObserveInt64(s.targetServicesGauge, atomic.LoadInt64(&s.currentTargetServices))
+			return nil
+		},
+		s.probeConfigsGauge, s.targetHostsGauge, s.targetServicesGauge,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register gauge callbacks: %w", err)
+	}
+
+	return s, nil
+}


### PR DESCRIPTION
This pull request introduces significant updates to the `maprobe` project, including enhancements to the CLI structure, OpenTelemetry (OTel) integration, and codebase simplifications. The changes improve observability, streamline command handling, and modernize the codebase by removing legacy components.

### CLI and Command Handling Updates:
* Introduced a new `CLI` structure in `cli.go` to define command-line interface options and commands, replacing the previous inline CLI parsing logic. This includes commands like `agent`, `once`, `lambda`, `ping`, `tcp`, `http`, and `firehose-endpoint`.
* Refactored `main.go` to use the new `CLI` structure, improving argument parsing and command execution. AWS Lambda-specific argument handling was streamlined, and the `maprobe.Main` function now handles command execution. [[1]](diffhunk://#diff-e8473f9cd31f512a32ee64c789702c677b72b8ff9efbbb9babf2c9e03cb0b228L36-R54) [[2]](diffhunk://#diff-e8473f9cd31f512a32ee64c789702c677b72b8ff9efbbb9babf2c9e03cb0b228L88-R102) [[3]](diffhunk://#diff-e8473f9cd31f512a32ee64c789702c677b72b8ff9efbbb9babf2c9e03cb0b228L155-L230)

### OpenTelemetry Integration:
* Added support for OpenTelemetry resource and stats attributes in `OtelConfig` to enhance observability. These attributes can now be configured in the YAML configuration. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R163-R167) [[2]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R45-R46)
* Integrated OpenTelemetry metrics into the `Run` function in `maprobe.go`, allowing metrics export through OTel exporters. The `postOtelMetricWorker` function was updated to leverage these new capabilities. [[1]](diffhunk://#diff-998980a0a50a3d0b04e0b72992347931fc527a71a96d802486dc326dffe53b2aR75-R101) [[2]](diffhunk://#diff-998980a0a50a3d0b04e0b72992347931fc527a71a96d802486dc326dffe53b2aL388-R358) [[3]](diffhunk://#diff-998980a0a50a3d0b04e0b72992347931fc527a71a96d802486dc326dffe53b2aL420-R381)

### Codebase Simplifications:
* Removed legacy methods and dependencies in `main.go`, such as `mackerelHost`, `runProbe`, and `setupSlog`, consolidating logging setup into the `maprobe` package.
* Updated imports in `maprobe.go` to include new dependencies like `sloghandler/otelmetrics` and replace deprecated or unused imports.

### Dependency Updates:
* Added new dependencies in `go.mod` for OpenTelemetry metrics (`otel/metric`) and terminal handling (`go-isatty`). Removed unused indirect dependencies. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R18-R28) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L54-L57)

These changes collectively enhance the functionality, maintainability, and observability of the `maprobe` project.