### PR TITLE
Add host.id to otel metrics if not empty.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,26 @@
+project_name: maprobe
+before:
+  hooks:
+    - go mod download
+builds:
+  - env:
+      - CGO_ENABLED=0
+    main: ./cmd/maprobe
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+checksum:
+  name_template: "checksums.txt"
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+release:
+  prerelease: "auto"

--- a/metric.go
+++ b/metric.go
@@ -155,10 +155,10 @@ func (a *Attribute) Otel() *otelattribute.Set {
 	for k, v := range a.Extra {
 		kvs = append(kvs, otelattribute.String(k, v))
 	}
-	kvs = append(kvs,
-		semconv.ServiceName(a.Service),
-		semconv.HostID(a.HostID),
-	)
+	kvs = append(kvs, semconv.ServiceName(a.Service))
+	if a.HostID != "" {
+		kvs = append(kvs, semconv.HostID(a.HostID))
+	}
 	s := otelattribute.NewSet(kvs...)
 	return &s
 }


### PR DESCRIPTION
This pull request introduces a new configuration for GoReleaser to streamline the build and release process, along with an improvement to the `Otel` method in `metric.go` to handle optional attributes more gracefully.

### Build and Release Configuration:

* [`.goreleaser.yml`](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689R1-R26): Added a new GoReleaser configuration file to define the project name, build settings, checksum generation, snapshot naming, changelog sorting, and release options. This configuration supports cross-platform builds for `darwin` and `linux` on `amd64` and `arm64` architectures. It also includes hooks for dependency management and filters for changelog entries.

### Codebase Improvement:

* [`metric.go`](diffhunk://#diff-8d576bc3a4aa3e5702bc143cbc94b90f5fd13c94bab3549bf31372a449fc89bfL158-R161): Updated the `Otel` method in the `Attribute` struct to conditionally append the `HostID` attribute only when it is non-empty, improving the robustness of telemetry data generation.