### PR TITLE
Add certificate expiration metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ TCP probe generates the following metrics.
 
 - tcp.check.ok (0 or 1)
 - tcp.elapsed.seconds (seconds)
+- tcp.certificate.expires_in_days (days until TLS certificate expires, only for TLS connections)
 
 ### HTTP
 
@@ -292,6 +293,7 @@ HTTP probe generates the following metrics.
 - http.response_time.seconds (seconds)
 - http.status.code (100~)
 - http.content.length (bytes)
+- http.certificate.expires_in_days (days until SSL/TLS certificate expires, only for HTTPS URLs)
 
 When a status code is grather than 400, http.check.ok set to 0.
 

--- a/http_test.go
+++ b/http_test.go
@@ -2,7 +2,14 @@ package maprobe_test
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"fmt"
+	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,6 +20,7 @@ import (
 )
 
 var HTTPServerURL string
+var HTTPSServerURL string
 
 func testHTTPServer() string {
 	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -21,6 +29,61 @@ func testHTTPServer() string {
 	})
 	ts := httptest.NewServer(handler)
 	return ts.URL
+}
+
+func testHTTPSServer() string {
+	var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		fmt.Fprintf(w, "Hello HTTPS Test")
+	})
+
+	// Generate a test certificate that expires in 30 days
+	cert, key := generateTestCertificate(30 * 24 * time.Hour)
+	
+	ts := httptest.NewUnstartedServer(handler)
+	ts.TLS = &tls.Config{
+		Certificates: []tls.Certificate{{
+			Certificate: [][]byte{cert.Raw},
+			PrivateKey:  key,
+		}},
+	}
+	ts.StartTLS()
+	return ts.URL
+}
+
+func generateTestCertificate(validFor time.Duration) (*x509.Certificate, *rsa.PrivateKey) {
+	// Generate private key
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create certificate template
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test"},
+		},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(validFor),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+		DNSNames:     []string{"localhost"},
+	}
+
+	// Create certificate
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		panic(err)
+	}
+
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		panic(err)
+	}
+
+	return cert, priv
 }
 
 func TestHTTP(t *testing.T) {
@@ -62,6 +125,63 @@ func TestHTTP(t *testing.T) {
 				t.Errorf("unexpected content length %f", m.Value)
 			}
 		}
+	}
+	t.Log(ms.String())
+}
+
+func TestHTTPS(t *testing.T) {
+	pc := &maprobe.HTTPProbeConfig{
+		URL:                HTTPSServerURL,
+		ExpectPattern:      "^Hello",
+		NoCheckCertificate: true, // Accept self-signed certificate
+	}
+
+	probe, err := pc.GenerateProbe(&mackerel.Host{ID: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(probe, err)
+
+	ms, err := probe.Run(context.Background())
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Should have 5 metrics: check.ok, response_time, status.code, content.length, certificate.expires_in_days
+	if len(ms) != 5 {
+		t.Errorf("unexpected metrics num: got %d, want 5", len(ms))
+	}
+	
+	var foundCertMetric bool
+	for _, m := range ms {
+		switch m.Name {
+		case "http.response_time.seconds":
+			if m.Value < 0.1 {
+				t.Error("elapsed time too short")
+			}
+		case "http.check.ok":
+			if m.Value != 1 {
+				t.Error("check failed")
+			}
+		case "http.status.code":
+			if m.Value != 200 {
+				t.Errorf("unexpected status %f", m.Value)
+			}
+		case "http.content.length":
+			if m.Value != 16 { // "Hello HTTPS Test"
+				t.Errorf("unexpected content length %f", m.Value)
+			}
+		case "http.certificate.expires_in_days":
+			foundCertMetric = true
+			// Should be around 30 days (certificate expires in 30 days)
+			if m.Value < 29 || m.Value > 31 {
+				t.Errorf("unexpected certificate expiration days: %f", m.Value)
+			}
+		}
+	}
+	
+	if !foundCertMetric {
+		t.Error("certificate.expires_in_days metric not found")
 	}
 	t.Log(ms.String())
 }

--- a/tcp_test.go
+++ b/tcp_test.go
@@ -3,6 +3,7 @@ package maprobe_test
 import (
 	"bufio"
 	"context"
+	"crypto/tls"
 	"io"
 	"net"
 	"os"
@@ -14,10 +15,13 @@ import (
 )
 
 var TCPServerAddress net.Addr
+var TLSServerAddress net.Addr
 
 func TestMain(m *testing.M) {
 	TCPServerAddress = testTCPServer()
+	TLSServerAddress = testTLSServer()
 	HTTPServerURL = testHTTPServer()
+	HTTPSServerURL = testHTTPSServer()
 	ret := m.Run()
 	os.Exit(ret)
 }
@@ -46,6 +50,45 @@ func testTCPServer() net.Addr {
 	}()
 	return l.Addr()
 }
+
+func testTLSServer() net.Addr {
+	// Generate a test certificate that expires in 30 days
+	cert, key := generateTestCertificate(30 * 24 * time.Hour)
+	
+	tlsCert := tls.Certificate{
+		Certificate: [][]byte{cert.Raw},
+		PrivateKey:  key,
+	}
+	
+	config := &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+	}
+	
+	l, err := tls.Listen("tcp", "127.0.0.1:0", config)
+	if err != nil {
+		panic(err)
+	}
+	
+	go func() {
+		defer l.Close()
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+			go func(conn net.Conn) {
+				time.Sleep(100 * time.Millisecond)
+				defer conn.Close()
+				scanner := bufio.NewScanner(conn)
+				for scanner.Scan() {
+					io.WriteString(conn, scanner.Text()+"\n")
+				}
+			}(conn)
+		}
+	}()
+	return l.Addr()
+}
+
 
 func TestTCP(t *testing.T) {
 	host, port, _ := net.SplitHostPort(TCPServerAddress.String())
@@ -116,6 +159,58 @@ func TestTCPFail(t *testing.T) {
 				t.Error("check failed")
 			}
 		}
+	}
+	t.Log(ms.String())
+}
+
+func TestTCPTLS(t *testing.T) {
+	host, port, _ := net.SplitHostPort(TLSServerAddress.String())
+
+	pc := &maprobe.TCPProbeConfig{
+		Host:               "{{.Host.Name}}",
+		Port:               port,
+		Send:               "hello\n",
+		ExpectPattern:      "^hello",
+		TLS:                true,
+		NoCheckCertificate: true, // Accept self-signed certificate
+	}
+
+	probe, err := pc.GenerateProbe(&mackerel.Host{ID: "test", Name: host})
+	if err != nil {
+		t.Error(err)
+	}
+	ms, err := probe.Run(context.Background())
+	if err != nil {
+		t.Error(err)
+	}
+	
+	// Should have 3 metrics: check.ok, elapsed.seconds, certificate.expires_in_days
+	if len(ms) != 3 {
+		t.Errorf("unexpected metrics num: got %d, want 3", len(ms))
+	}
+	
+	var foundCertMetric bool
+	for _, m := range ms {
+		switch m.Name {
+		case "tcp.elapsed.seconds":
+			if m.Value < 0.1 {
+				t.Error("elapsed time too short")
+			}
+		case "tcp.check.ok":
+			if m.Value != 1 {
+				t.Error("check failed")
+			}
+		case "tcp.certificate.expires_in_days":
+			foundCertMetric = true
+			// Should be around 30 days (certificate expires in 30 days)
+			if m.Value < 29 || m.Value > 31 {
+				t.Errorf("unexpected certificate expiration days: %f", m.Value)
+			}
+		}
+	}
+	
+	if !foundCertMetric {
+		t.Error("certificate.expires_in_days metric not found")
 	}
 	t.Log(ms.String())
 }


### PR DESCRIPTION
This pull request introduces support for monitoring SSL/TLS certificate expiration in both HTTP and TCP probes. It adds a new metric, `certificate.expires_in_days`, and includes corresponding implementation and tests. The changes ensure that the metric is reported for HTTPS and TLS connections, along with validation in unit tests.

### New Feature: SSL/TLS Certificate Expiration Metric

**HTTP Probe Enhancements:**
* Added `http.certificate.expires_in_days` metric to report the days until the SSL/TLS certificate expires for HTTPS URLs. [[1]](diffhunk://#diff-6971e2713fe98b79ea18e9748bf68928f6ebcd4d93e7a27f10e7472ce6d78a48R156-R163) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R296)
* Updated the `README.md` to document the new metric for HTTP probes.

**TCP Probe Enhancements:**
* Added `tcp.certificate.expires_in_days` metric to report the days until the TLS certificate expires for TLS connections. [[1]](diffhunk://#diff-4d5e034440481320d64aad71055aedc5483b1d73957bc46681d1384acdd76db8R145-R158) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R271)
* Updated the `README.md` to document the new metric for TCP probes.

### Code Changes for Metric Implementation
* Modified the `Run` method in `http.go` to calculate and append the certificate expiration metric for HTTPS responses.
* Modified the `Run` method in `tcp.go` to calculate and append the certificate expiration metric for TLS connections.
* Introduced a `hostID` field in `TCPProbe` to support additional functionality. [[1]](diffhunk://#diff-4d5e034440481320d64aad71055aedc5483b1d73957bc46681d1384acdd76db8R39) [[2]](diffhunk://#diff-4d5e034440481320d64aad71055aedc5483b1d73957bc46681d1384acdd76db8R89) [[3]](diffhunk://#diff-4d5e034440481320d64aad71055aedc5483b1d73957bc46681d1384acdd76db8R103-R106)

### Unit Tests for Certificate Expiration
* Added a new `TestHTTPS` function in `http_test.go` to validate the `http.certificate.expires_in_days` metric for HTTPS connections using a self-signed certificate.
* Added a new `TestTCPTLS` function in `tcp_test.go` to validate the `tcp.certificate.expires_in_days` metric for TLS connections using a self-signed certificate.
* Created utility functions (`generateTestCertificate`, `testHTTPSServer`, `testTLSServer`) to generate test certificates and servers for HTTPS and TLS testing. [[1]](diffhunk://#diff-07aaefdb2814a4c16ad5de02d682fd2657ea5cb65de7aef0eb7168d951fc4c29R34-R88) [[2]](diffhunk://#diff-29bd318fcf49d4eb4f04baf500afdc37893c40165d397005e86f0338df49fb41R54-R92)