### PR TITLE
Add support for additional attributes in command probe metrics

### DIFF
--- a/command.go
+++ b/command.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -278,31 +277,4 @@ func (p *CommandProbe) GetGraphDefs() (*GraphsOutput, error) {
 		return nil, fmt.Errorf("could not decode graph defs output: %w", err)
 	}
 	return &out, nil
-}
-
-func parseMetricLine(b string) (Metric, error) {
-	cols := strings.SplitN(b, "\t", 3)
-	if len(cols) < 3 {
-		return Metric{}, fmt.Errorf("invalid metric format. insufficient columns")
-	}
-	name, value, timestamp := cols[0], cols[1], cols[2]
-	if name == "" {
-		return Metric{}, fmt.Errorf("invalid metric format. name is empty")
-	}
-	m := Metric{
-		Name: name,
-	}
-	if v, err := strconv.ParseFloat(value, 64); err != nil {
-		return m, fmt.Errorf("invalid metric value: %s", value)
-	} else {
-		m.Value = v
-	}
-
-	if ts, err := strconv.ParseInt(timestamp, 10, 64); err != nil {
-		return m, fmt.Errorf("invalid metric time: %s", timestamp)
-	} else {
-		m.Timestamp = time.Unix(ts, 0)
-	}
-
-	return m, nil
 }

--- a/metric.go
+++ b/metric.go
@@ -3,6 +3,7 @@ package maprobe
 import (
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"time"
 
@@ -37,6 +38,9 @@ func (m Metric) Otel() otelmetricdata.Metrics {
 
 func (m Metric) OtelString() string {
 	// promhttp_metric_handler_requests_total{code="200"} 988
+	if m.Attribute == nil {
+		return fmt.Sprintf("%s %f %s", m.Name, m.Value, m.Timestamp.Format(time.RFC3339))
+	}
 	return fmt.Sprintf("%s{%s} %f %s", m.Name, m.Attribute, m.Value, m.Timestamp.Format(time.RFC3339))
 }
 
@@ -159,7 +163,7 @@ func (a *Attribute) Otel() *otelattribute.Set {
 			serviceNameSet = true
 		}
 	}
-	if !serviceNameSet {
+	if !serviceNameSet && a.Service != "" {
 		// set service name if not already set
 		kvs = append(kvs, semconv.ServiceName(a.Service))
 	}
@@ -171,5 +175,52 @@ func (a *Attribute) Otel() *otelattribute.Set {
 }
 
 func (a Attribute) String() string {
-	return a.Otel().Encoded(otelattribute.DefaultEncoder())
+	s := a.Otel()
+	return s.Encoded(otelattribute.DefaultEncoder())
+}
+
+func parseMetricLine(b string) (Metric, error) {
+	cols := strings.Split(b, "\t")
+	if len(cols) < 3 {
+		return Metric{}, fmt.Errorf("invalid metric format. insufficient columns")
+	}
+	name, value, timestamp := cols[0], cols[1], cols[2]
+	if name == "" {
+		return Metric{}, fmt.Errorf("invalid metric format. name is empty")
+	}
+	m := Metric{
+		Name: name,
+	}
+	if v, err := strconv.ParseFloat(value, 64); err != nil {
+		return m, fmt.Errorf("invalid metric value: %s", value)
+	} else {
+		m.Value = v
+	}
+
+	if ts, err := strconv.ParseInt(timestamp, 10, 64); err != nil {
+		_ts, err := strconv.ParseFloat(timestamp, 64)
+		if err != nil {
+			return m, fmt.Errorf("invalid metric time: %s", timestamp)
+		}
+		m.Timestamp = time.Unix(int64(_ts), 0)
+	} else {
+		m.Timestamp = time.Unix(ts, 0)
+	}
+
+	if len(cols) == 3 {
+		return m, nil
+	}
+
+	// Handle additional attributes
+	attr := &Attribute{
+		Extra: make(map[string]string, len(cols)-3),
+	}
+	for _, ext := range cols[3:] {
+		c := strings.SplitN(ext, "=", 2)
+		if len(c) == 2 {
+			attr.Extra[c[0]] = c[1]
+		}
+	}
+	m.Attribute = attr
+	return m, nil
 }

--- a/metric_test.go
+++ b/metric_test.go
@@ -1,0 +1,52 @@
+package maprobe_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/fujiwara/maprobe"
+	"github.com/google/go-cmp/cmp"
+)
+
+var metricTests = []struct {
+	input    string
+	expected maprobe.Metric
+}{
+	{
+		input:    "foo.bar\t42\t1755680137",
+		expected: maprobe.Metric{Name: "foo.bar", Value: 42, Timestamp: time.Unix(1755680137, 0)},
+	},
+	{
+		input:    "foo.bar.baz\t42.123\t1755680137",
+		expected: maprobe.Metric{Name: "foo.bar.baz", Value: float64(42.123), Timestamp: time.Unix(1755680137, 0)},
+	},
+	{
+		input: "foo.bar.baz\t42.123\t1755680137.888\tattr1=value1\tattr2=value2",
+		expected: maprobe.Metric{
+			Name:      "foo.bar.baz",
+			Value:     float64(42.123),
+			Timestamp: time.Unix(1755680137, 0),
+			Attribute: &maprobe.Attribute{
+				Extra: map[string]string{
+					"attr1": "value1",
+					"attr2": "value2",
+				},
+			},
+		},
+	},
+}
+
+func TestParseMetricLine(t *testing.T) {
+	for _, test := range metricTests {
+		t.Run(test.input, func(t *testing.T) {
+			m, err := maprobe.ParseMetricLine(test.input)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(test.expected, m); diff != "" {
+				t.Errorf("unexpected diff (-want +got):\n%s", diff)
+			}
+			t.Log(m.OtelString())
+		})
+	}
+}


### PR DESCRIPTION
- Support key=value format attributes in command probe output
- Attributes are sent to OpenTelemetry metrics endpoint only
- Move parseMetricLine function from command.go to metric.go
- Add support for float timestamp parsing
- Update documentation with attribute usage examples
- Add comprehensive tests for metric parsing with attributes

🤖 Generated with [Claude Code](https://claude.ai/code)